### PR TITLE
Enhance process management, resource limits, and VFS operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,19 +80,19 @@ BUILD_SYSROOT := $(BUILD_DIR)/sysroot
 MUSL_PREFIX ?= $(BUILD_USERS_DIR)/musl
 MUSL_INCLUDE_DIR := $(MUSL_PREFIX)/include
 MUSL_LIB_DIR := $(MUSL_PREFIX)/lib
+LEGACY_INIT_TARGET := $(BUILD_USER_DIR)/init.elf
 MUSL_INIT_TARGET := $(BUILD_USERS_DIR)/init/init-musl.elf
 BLUEYOS_SYSROOT ?= /opt/blueyos-sysroot
 BLUEYOS_CROSS ?= /opt/blueyos-cross
 BLUEYOS_CROSS_MUSL ?= $(BLUEYOS_CROSS)/musl
-# Optional external sysroot to assemble disk images from (preferred when present)
-# If this directory exists, disk builds will use it instead of the locally
-# assembled $(BUILD_SYSROOT).
-SYSROOT_SRC ?= /opt/blueyos-sysroot
-ifeq ($(shell [ -d $(SYSROOT_SRC) ] && echo yes),yes)
-  ROOT_EXTRA_DIR := $(SYSROOT_SRC)
-else
-  ROOT_EXTRA_DIR := $(BUILD_SYSROOT)
-endif
+# Optional sysroot source to assemble disk images from. By default the disk
+# image is populated from the curated local $(BUILD_SYSROOT); callers can
+# override SYSROOT_SRC to point at an external staging tree when needed.
+SYSROOT_SRC ?= $(BUILD_SYSROOT)
+ROOT_EXTRA_DIR := $(SYSROOT_SRC)
+ROOT_EXTRA_ARG = $(if $(wildcard $(ROOT_EXTRA_DIR)),--root-extra-dir $(ROOT_EXTRA_DIR))
+BOOT_EXTRA_DIR := $(ROOT_EXTRA_DIR)/boot
+BOOT_EXTRA_ARG = $(if $(wildcard $(BOOT_EXTRA_DIR)),--boot-extra-dir $(BOOT_EXTRA_DIR))
 
 # ---------------------------------------------------------------------------
 # Architecture-specific compiler / assembler / linker flags
@@ -320,9 +320,7 @@ else
   C_SOURCES   = $(I386_C_SOURCES)
   ASM_SOURCES = $(I386_ASM_SOURCES)
   TARGET      = $(BUILD_KERNEL_DIR)/bkernel
-  # Prefer musl-backed init when present (build userspace musl with `make musl-init`).
-  # This makes the musl-test init the default payload until the new `claw` init is ready.
-  USER_TARGETS = $(MUSL_INIT_TARGET) $(BUILD_USER_DIR)/init.elf
+  USER_TARGETS = $(LEGACY_INIT_TARGET) $(MUSL_INIT_TARGET)
 endif
 
 ISO    = $(BUILD_DIR)/blueyos.iso
@@ -415,19 +413,12 @@ $(TARGET): $(OBJECTS)
 
 iso: $(TARGET) ; @if [ "$(ARCH)" != "i386" ]; then echo "  [ISO]  ISO build is only supported for ARCH=i386"; exit 1; fi; BUILD_DIR=$(BUILD_DIR) bash tools/mkdisk.sh
 
-sysroot: $(TARGET) $(MUSL_INIT_TARGET) | $(BUILD_SYSROOT)
-	@echo "  [SYSROOT] Assembling $(BUILD_SYSROOT)"
-	@mkdir -p $(BUILD_SYSROOT)/boot $(BUILD_SYSROOT)/bin $(BUILD_SYSROOT)/lib $(BUILD_SYSROOT)/etc
-	@cp -f $(TARGET) $(BUILD_SYSROOT)/boot/bkernel
-	@if [ -f $(MUSL_INIT_TARGET) ]; then cp -f $(MUSL_INIT_TARGET) $(BUILD_SYSROOT)/bin/init; fi
-	@if [ -d $(BUILD_USERS_DIR)/bash/bin ]; then cp -a $(BUILD_USERS_DIR)/bash/bin/* $(BUILD_SYSROOT)/bin/ 2>/dev/null || true; fi
-	@if [ -d $(MUSL_LIB_DIR) ]; then cp -a $(MUSL_LIB_DIR)/* $(BUILD_SYSROOT)/lib/ 2>/dev/null || true; fi
-	@echo "  [SYSROOT] ready"
+sysroot: $(TARGET) $(LEGACY_INIT_TARGET) | $(BUILD_SYSROOT) ; @echo "  [SYSROOT] Assembling $(BUILD_SYSROOT)"; mkdir -p $(BUILD_SYSROOT)/boot $(BUILD_SYSROOT)/bin $(BUILD_SYSROOT)/lib $(BUILD_SYSROOT)/etc; cp -f $(TARGET) $(BUILD_SYSROOT)/boot/bkernel; if [ -f $(MUSL_INIT_TARGET) ]; then cp -f $(MUSL_INIT_TARGET) $(BUILD_SYSROOT)/bin/init; else cp -f $(LEGACY_INIT_TARGET) $(BUILD_SYSROOT)/bin/init; fi; if [ -d $(BUILD_USERS_DIR)/bash/bin ]; then cp -a $(BUILD_USERS_DIR)/bash/bin/* $(BUILD_SYSROOT)/bin/ 2>/dev/null || true; fi; if [ -d $(MUSL_LIB_DIR) ]; then cp -a $(MUSL_LIB_DIR)/* $(BUILD_SYSROOT)/lib/ 2>/dev/null || true; fi; echo "  [SYSROOT] ready"
 
 
-disk: $(TARGET) tools-host ; @if [ "$(ARCH)" != "i386" ]; then echo "  [DISK]  Disk image build is only supported for ARCH=i386"; exit 1; fi; $(PYTHON) tools/mkbluey_disk.py --image $(DISK_IMAGE) --kernel $(TARGET) --root-extra-dir $(ROOT_EXTRA_DIR) --boot-extra-dir $(ROOT_EXTRA_DIR)/boot --mkfs-tool $(MKFS_BLUEYFS) --mkswap-tool $(MKSWAP_BLUEYFS) $(DISK_ERASE_FLAG)
+disk: $(TARGET) $(LEGACY_INIT_TARGET) sysroot tools-host ; @if [ "$(ARCH)" != "i386" ]; then echo "  [DISK]  Disk image build is only supported for ARCH=i386"; exit 1; fi; $(PYTHON) tools/mkbluey_disk.py --image $(DISK_IMAGE) --kernel $(TARGET) --init $(LEGACY_INIT_TARGET) $(ROOT_EXTRA_ARG) $(BOOT_EXTRA_ARG) --mkfs-tool $(MKFS_BLUEYFS) --mkswap-tool $(MKSWAP_BLUEYFS) $(DISK_ERASE_FLAG)
 
-disk-musl: $(TARGET) $(MUSL_INIT_TARGET) tools-host ; @if [ "$(ARCH)" != "i386" ]; then echo "  [DISK]  Disk image build is only supported for ARCH=i386"; exit 1; fi; $(PYTHON) tools/mkbluey_disk.py --image $(DISK_IMAGE) --kernel $(TARGET) --root-extra-dir $(ROOT_EXTRA_DIR) --boot-extra-dir $(ROOT_EXTRA_DIR)/boot --mkfs-tool $(MKFS_BLUEYFS) --mkswap-tool $(MKSWAP_BLUEYFS) $(DISK_ERASE_FLAG)
+disk-musl: $(TARGET) $(MUSL_INIT_TARGET) tools-host ; @if [ "$(ARCH)" != "i386" ]; then echo "  [DISK]  Disk image build is only supported for ARCH=i386"; exit 1; fi; $(PYTHON) tools/mkbluey_disk.py --image $(DISK_IMAGE) --kernel $(TARGET) --init $(MUSL_INIT_TARGET) $(ROOT_EXTRA_ARG) $(BOOT_EXTRA_ARG) --mkfs-tool $(MKFS_BLUEYFS) --mkswap-tool $(MKSWAP_BLUEYFS) $(DISK_ERASE_FLAG)
 
 fat-log-disk:
 	@bash tools/mkfat_logs_disk.sh "$(LOG_DISK_IMAGE)"
@@ -478,7 +469,7 @@ $(MOUNT_BLUEYFS): tools/mount_blueyfs.c ; @mkdir -p $(dir $@); \
   gcc -O2 -Wall -Wextra -o $@ $< $$(pkg-config --cflags --libs fuse3); \
   echo "  [CC]  $< (host, fuse3)"
 
-$(BUILD_USER_DIR)/init.elf: user/init.c ; @mkdir -p $(dir $@); gcc -m32 -std=gnu11 -ffreestanding -O2 -Wall -Wextra -fno-stack-protector -nostdlib -fno-builtin -fno-pic -no-pie -Wl,-m,elf_i386 -Wl,-Ttext,0x00400000 -o $@ $<; echo "  [LD]  $@"
+$(LEGACY_INIT_TARGET): user/init.c ; @mkdir -p $(dir $@); gcc -m32 -std=gnu11 -ffreestanding -O2 -Wall -Wextra -fno-stack-protector -nostdlib -fno-builtin -fno-pic -no-pie -Wl,-m,elf_i386 -Wl,-Ttext,0x00400000 -o $@ $<; echo "  [LD]  $@"
 
 # Module tools (insmod, rmmod)
 $(BUILD_USER_DIR)/insmod: user/insmod.c ; @mkdir -p $(dir $@); gcc -m32 -std=gnu11 -ffreestanding -O2 -Wall -Wextra -fno-stack-protector -nostdlib -fno-builtin -fno-pic -no-pie -Wl,-m,elf_i386 -Wl,-Ttext,0x00400000 -o $@ $<; echo "  [LD]  $@"

--- a/Makefile
+++ b/Makefile
@@ -259,6 +259,7 @@ I386_C_SOURCES = \
     fs/fat.c \
     fs/blueyfs.c \
     fs/procfs.c \
+    fs/devfs.c \
     net/tcpip.c \
     net/arp.c \
     net/ip.c \

--- a/Makefile
+++ b/Makefile
@@ -327,6 +327,8 @@ endif
 
 ISO    = $(BUILD_DIR)/blueyos.iso
 DISK_IMAGE = $(BUILD_DIR)/blueyos-disk.img
+ERASE ?= 0
+DISK_ERASE_FLAG = $(if $(filter 1,$(ERASE)),--erase,)
 LOG_DISK_IMAGE ?= $(BUILD_DIR)/blueyos-log-fat.img
 MKFS_BLUEYFS = $(BUILD_TOOLS_DIR)/mkfs_blueyfs
 MKSWAP_BLUEYFS = $(BUILD_TOOLS_DIR)/mkswap_blueyfs
@@ -423,9 +425,9 @@ sysroot: $(TARGET) $(MUSL_INIT_TARGET) | $(BUILD_SYSROOT)
 	@echo "  [SYSROOT] ready"
 
 
-disk: $(TARGET) tools-host ; @if [ "$(ARCH)" != "i386" ]; then echo "  [DISK]  Disk image build is only supported for ARCH=i386"; exit 1; fi; $(PYTHON) tools/mkbluey_disk.py --image $(DISK_IMAGE) --kernel $(TARGET) --root-extra-dir $(ROOT_EXTRA_DIR) --boot-extra-dir $(ROOT_EXTRA_DIR)/boot --mkfs-tool $(MKFS_BLUEYFS) --mkswap-tool $(MKSWAP_BLUEYFS)
+disk: $(TARGET) tools-host ; @if [ "$(ARCH)" != "i386" ]; then echo "  [DISK]  Disk image build is only supported for ARCH=i386"; exit 1; fi; $(PYTHON) tools/mkbluey_disk.py --image $(DISK_IMAGE) --kernel $(TARGET) --root-extra-dir $(ROOT_EXTRA_DIR) --boot-extra-dir $(ROOT_EXTRA_DIR)/boot --mkfs-tool $(MKFS_BLUEYFS) --mkswap-tool $(MKSWAP_BLUEYFS) $(DISK_ERASE_FLAG)
 
-disk-musl: $(TARGET) $(MUSL_INIT_TARGET) tools-host ; @if [ "$(ARCH)" != "i386" ]; then echo "  [DISK]  Disk image build is only supported for ARCH=i386"; exit 1; fi; $(PYTHON) tools/mkbluey_disk.py --image $(DISK_IMAGE) --kernel $(TARGET) --root-extra-dir $(ROOT_EXTRA_DIR) --boot-extra-dir $(ROOT_EXTRA_DIR)/boot --mkfs-tool $(MKFS_BLUEYFS) --mkswap-tool $(MKSWAP_BLUEYFS)
+disk-musl: $(TARGET) $(MUSL_INIT_TARGET) tools-host ; @if [ "$(ARCH)" != "i386" ]; then echo "  [DISK]  Disk image build is only supported for ARCH=i386"; exit 1; fi; $(PYTHON) tools/mkbluey_disk.py --image $(DISK_IMAGE) --kernel $(TARGET) --root-extra-dir $(ROOT_EXTRA_DIR) --boot-extra-dir $(ROOT_EXTRA_DIR)/boot --mkfs-tool $(MKFS_BLUEYFS) --mkswap-tool $(MKSWAP_BLUEYFS) $(DISK_ERASE_FLAG)
 
 fat-log-disk:
 	@bash tools/mkfat_logs_disk.sh "$(LOG_DISK_IMAGE)"
@@ -540,11 +542,11 @@ help:
 	@echo "  make ARCH=m68k        - build M68K kernel (Macintosh LC III)"
 	@echo "  make ARCH=ppc         - build PowerPC kernel (iMac G4 Sunflower)"
 	@echo "  make iso              - create bootable ISO (i386 only)"
-	@echo "  make disk             - create a partitioned BlueyOS disk image (root auto-sized from sysroot +30%)"
+	@echo "  make disk             - sync sysroot into disk image (reuse layout by default; ERASE=1 forces fresh image)"
 	@echo "  make fat-log-disk     - create an optional FAT16 log disk image at $(LOG_DISK_IMAGE)"
 	@echo "  make $(MOUNT_BLUEYFS) - build the read-only Linux FUSE BiscuitFS mounter"
 	@echo "  make musl-init        - build static musl test init at $(MUSL_INIT_TARGET)"
-	@echo "  make disk-musl        - create a disk image using the musl test init (root auto-sized from sysroot +30%)"
+	@echo "  make disk-musl        - sync disk image using musl init flow (ERASE=1 forces fresh image)"
 	@echo "  make run              - build ISO and launch in QEMU (i386 only)"
 	@echo "  make run-m68k         - launch M68K QEMU with detached serial capture"
 	@echo "  make tools-host       - build host-side mkfs/mkswap/fsck tools"

--- a/fs/blueyfs.c
+++ b/fs/blueyfs.c
@@ -57,7 +57,7 @@ static uint32_t        jnl_seq       = 1;
 static uint32_t        jnl_start_blk = 0;  /* first block of journal region */
 
 // Open file table
-#define BISCUITFS_MAX_OPEN  16
+#define BISCUITFS_MAX_OPEN  1024
 typedef struct {
     int      used;
     uint32_t inode_no;

--- a/fs/devfs.c
+++ b/fs/devfs.c
@@ -1,0 +1,341 @@
+// BlueyOS devfs — "Bandit's Toolbelt"
+// An in-memory virtual filesystem mounted at /dev.
+//
+// Episode ref: "Dad Baby" — every tool has its place.
+//
+// ⚠️  VIBE CODED RESEARCH PROJECT — NOT FOR PRODUCTION USE ⚠️
+//
+// Bluey and all related characters are trademarks of Ludo Studio Pty Ltd,
+// licensed by BBC Studios. BlueyOS is an unofficial fan/research project
+// with no affiliation to Ludo Studio or the BBC.
+
+#include "devfs.h"
+#include "../include/types.h"
+#include "../lib/string.h"
+#include "../lib/stdio.h"
+#include "../kernel/tty.h"
+#include "../kernel/timer.h"
+#include "vfs.h"
+
+// ---------------------------------------------------------------------------
+// Node types
+// ---------------------------------------------------------------------------
+#define DEVNODE_NULL     1   // /dev/null — reads return 0, writes discard
+#define DEVNODE_ZERO     2   // /dev/zero — reads return 0x00 bytes
+#define DEVNODE_RANDOM   3   // /dev/random, /dev/urandom — PRNG bytes
+#define DEVNODE_TTY_CON  4   // /dev/console, /dev/tty0, /dev/tty1, /dev/ttyS0
+#define DEVNODE_TTY_CTL  5   // /dev/tty — process controlling terminal
+#define DEVNODE_DISK     6   // /dev/disk* — whole-disk block nodes (stat only)
+#define DEVNODE_PART     7   // /dev/disk*s* — partition block nodes (stat only)
+#define DEVNODE_FLOPPY   8   // /dev/fd* — floppy block nodes (stat only)
+#define DEVNODE_NET      9   // /dev/eth*, /dev/wifi* — net char nodes (stat only)
+#define DEVNODE_STDIN    10  // /dev/stdin  — alias to TTY_CTL
+#define DEVNODE_STDOUT   11  // /dev/stdout — alias to TTY_CTL
+#define DEVNODE_STDERR   12  // /dev/stderr — alias to TTY_CTL
+
+// ---------------------------------------------------------------------------
+// Static device node table
+// ---------------------------------------------------------------------------
+typedef struct {
+    const char *name;    // basename under /dev/
+    uint8_t     type;    // DEVNODE_* constant
+    uint16_t    mode;    // VFS mode bits
+} devfs_node_t;
+
+static const devfs_node_t devfs_nodes[] = {
+    // character devices
+    { "null",    DEVNODE_NULL,    VFS_S_IFCHR | 0666 },
+    { "zero",    DEVNODE_ZERO,    VFS_S_IFCHR | 0666 },
+    { "random",  DEVNODE_RANDOM,  VFS_S_IFCHR | 0444 },
+    { "urandom", DEVNODE_RANDOM,  VFS_S_IFCHR | 0444 },
+    // tty devices
+    { "console", DEVNODE_TTY_CON, VFS_S_IFCHR | 0620 },
+    { "tty",     DEVNODE_TTY_CTL, VFS_S_IFCHR | 0666 },
+    { "tty0",    DEVNODE_TTY_CON, VFS_S_IFCHR | 0620 },
+    { "tty1",    DEVNODE_TTY_CON, VFS_S_IFCHR | 0620 },
+    { "ttyS0",   DEVNODE_TTY_CON, VFS_S_IFCHR | 0620 },
+    // stdio aliases
+    { "stdin",   DEVNODE_STDIN,   VFS_S_IFCHR | 0666 },
+    { "stdout",  DEVNODE_STDOUT,  VFS_S_IFCHR | 0666 },
+    { "stderr",  DEVNODE_STDERR,  VFS_S_IFCHR | 0666 },
+    // floppy drives
+    { "fd0",     DEVNODE_FLOPPY,  VFS_S_IFBLK | 0660u },
+    { "fd1",     DEVNODE_FLOPPY,  VFS_S_IFBLK | 0660u },
+    // ATA/SATA disks (BSD-style: disk0, disk1, …)
+    { "disk0",   DEVNODE_DISK,    VFS_S_IFBLK | 0660u },
+    { "disk1",   DEVNODE_DISK,    VFS_S_IFBLK | 0660u },
+    // Partitions/slices (BSD-style: disk0s1, disk0s2, disk0s3)
+    { "disk0s1", DEVNODE_PART,    VFS_S_IFBLK | 0660u },
+    { "disk0s2", DEVNODE_PART,    VFS_S_IFBLK | 0660u },
+    { "disk0s3", DEVNODE_PART,    VFS_S_IFBLK | 0660u },
+    { "disk1s1", DEVNODE_PART,    VFS_S_IFBLK | 0660u },
+    { "disk1s2", DEVNODE_PART,    VFS_S_IFBLK | 0660u },
+    { "disk1s3", DEVNODE_PART,    VFS_S_IFBLK | 0660u },
+    // Ethernet interfaces
+    { "eth0",    DEVNODE_NET,     VFS_S_IFCHR | 0640u },
+    { "eth1",    DEVNODE_NET,     VFS_S_IFCHR | 0640u },
+    { "eth2",    DEVNODE_NET,     VFS_S_IFCHR | 0640u },
+    { "eth3",    DEVNODE_NET,     VFS_S_IFCHR | 0640u },
+    // Wireless interfaces
+    { "wifi0",   DEVNODE_NET,     VFS_S_IFCHR | 0640u },
+    { "wifi1",   DEVNODE_NET,     VFS_S_IFCHR | 0640u },
+};
+#define DEVFS_NODE_COUNT ((int)(sizeof(devfs_nodes) / sizeof(devfs_nodes[0])))
+
+// ---------------------------------------------------------------------------
+// Open fd table
+// ---------------------------------------------------------------------------
+#define DEVFS_MAX_OPEN 1024
+
+typedef struct {
+    int     used;
+    uint8_t node_type;
+} devfs_fd_t;
+
+static devfs_fd_t devfs_fds[DEVFS_MAX_OPEN];
+
+// ---------------------------------------------------------------------------
+// PRNG — simple XorShift32, seeded lazily from the timer tick counter
+// ---------------------------------------------------------------------------
+static uint32_t devfs_prng_state = 0;
+
+static uint32_t devfs_rand(void) {
+    if (devfs_prng_state == 0) {
+        devfs_prng_state = timer_get_ticks();
+        if (devfs_prng_state == 0) devfs_prng_state = 0xDEADBEEFu;
+    }
+    uint32_t x = devfs_prng_state;
+    x ^= x << 13;
+    x ^= x >> 17;
+    x ^= x << 5;
+    devfs_prng_state = x;
+    return x;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/* Return a pointer to the node entry matching path, or NULL. */
+static const devfs_node_t *devfs_lookup(const char *path) {
+    if (!path) return NULL;
+
+    /* Strip the /dev/ prefix — accept both "/dev/foo" and "foo" */
+    const char *name = path;
+    if (name[0] == '/' && name[1] == 'd' && name[2] == 'e' &&
+        name[3] == 'v' && name[4] == '/') {
+        name = path + 5;  /* skip "/dev/" */
+    } else if (name[0] == '/') {
+        return NULL;  /* some other absolute path — not ours */
+    }
+
+    for (int i = 0; i < DEVFS_NODE_COUNT; i++) {
+        if (strcmp(devfs_nodes[i].name, name) == 0)
+            return &devfs_nodes[i];
+    }
+    return NULL;
+}
+
+/* Allocate a devfs-local fd slot. Returns index in devfs_fds or -1. */
+static int devfs_alloc_fd(uint8_t node_type) {
+    for (int i = 0; i < DEVFS_MAX_OPEN; i++) {
+        if (!devfs_fds[i].used) {
+            devfs_fds[i].used      = 1;
+            devfs_fds[i].node_type = node_type;
+            return i;
+        }
+    }
+    return -1;
+}
+
+// ---------------------------------------------------------------------------
+// Filesystem vtable callbacks
+// ---------------------------------------------------------------------------
+
+static int devfs_mount_cb(const char *mountpoint, uint32_t start_lba) {
+    (void)mountpoint;
+    (void)start_lba;
+    memset(devfs_fds, 0, sizeof(devfs_fds));
+    devfs_prng_state = 0;
+    kprintf("[DEVFS] Mounted at %s — %d devices registered\n",
+            mountpoint ? mountpoint : "/dev", DEVFS_NODE_COUNT);
+    return 0;
+}
+
+static int devfs_open_cb(const char *path, int flags) {
+    const devfs_node_t *node = devfs_lookup(path);
+    if (!node) return -1;
+
+    /* devfs is structurally read-only (no dynamic node creation), but opening
+     * existing nodes with O_CREAT/O_TRUNC is common from shell redirections
+     * (e.g. ">/dev/null"). Linux accepts this for device nodes, so do too. */
+    (void)flags;
+
+    /* Block devices and net nodes are not directly readable/writable via
+     * open() — they are accessed through the rootfs/VFS mount layer or the
+     * network stack respectively. */
+    if (node->type == DEVNODE_DISK || node->type == DEVNODE_PART ||
+        node->type == DEVNODE_FLOPPY || node->type == DEVNODE_NET) return -1;
+
+    return devfs_alloc_fd(node->type);
+}
+
+static int devfs_read_cb(int fd, uint8_t *buf, size_t len) {
+    if (fd < 0 || fd >= DEVFS_MAX_OPEN || !devfs_fds[fd].used) return -1;
+    if (!buf || len == 0) return 0;
+
+    switch (devfs_fds[fd].node_type) {
+        case DEVNODE_NULL:
+            return 0;   /* EOF immediately */
+
+        case DEVNODE_ZERO:
+            memset(buf, 0, len);
+            return (int)len;
+
+        case DEVNODE_RANDOM:
+            for (size_t i = 0; i < len; ) {
+                uint32_t r = devfs_rand();
+                size_t chunk = len - i < 4 ? len - i : 4;
+                for (size_t b = 0; b < chunk; b++, i++)
+                    buf[i] = (uint8_t)(r >> (b * 8));
+            }
+            return (int)len;
+
+        case DEVNODE_TTY_CON:
+        case DEVNODE_TTY_CTL:
+        case DEVNODE_STDIN:
+            return tty_read((char*)buf, len);
+
+        case DEVNODE_STDOUT:
+        case DEVNODE_STDERR:
+            /* These aren't sensible to read from, but return 0 gracefully */
+            return 0;
+
+        default:
+            return -1;
+    }
+}
+
+static int devfs_write_cb(int fd, const uint8_t *buf, size_t len) {
+    if (fd < 0 || fd >= DEVFS_MAX_OPEN || !devfs_fds[fd].used) return -1;
+    if (!buf || len == 0) return 0;
+
+    switch (devfs_fds[fd].node_type) {
+        case DEVNODE_NULL:
+            return (int)len;   /* discard all writes */
+
+        case DEVNODE_ZERO:
+            return (int)len;   /* also discard */
+
+        case DEVNODE_RANDOM:
+            /* Writing to /dev/random adds entropy — seed our PRNG */
+            if (len >= 4) {
+                uint32_t seed;
+                memcpy(&seed, buf, 4);
+                devfs_prng_state ^= seed ^ timer_get_ticks();
+            }
+            return (int)len;
+
+        case DEVNODE_TTY_CON:
+        case DEVNODE_TTY_CTL:
+        case DEVNODE_STDOUT:
+        case DEVNODE_STDERR:
+            tty_write((const char*)buf, len);
+            tty_flush();
+            return (int)len;
+
+        case DEVNODE_STDIN:
+            return -1;   /* stdin is not writable */
+
+        case DEVNODE_DISK:
+        case DEVNODE_PART:
+        case DEVNODE_FLOPPY:
+        case DEVNODE_NET:
+            return -1;
+
+        default:
+            return -1;
+    }
+}
+
+static int devfs_read_at_cb(int fd, uint8_t *buf, size_t len, uint32_t offset) {
+    /* Character devices have no meaningful offset — delegate to sequential read */
+    (void)offset;
+    return devfs_read_cb(fd, buf, len);
+}
+
+static int devfs_close_cb(int fd) {
+    if (fd < 0 || fd >= DEVFS_MAX_OPEN) return -1;
+    devfs_fds[fd].used      = 0;
+    devfs_fds[fd].node_type = 0;
+    return 0;
+}
+
+static int devfs_stat_cb(const char *path, vfs_stat_t *out) {
+    if (!out) return -1;
+
+    /* stat("/dev") or stat("/dev/") — report as directory */
+    if (strcmp(path, "/dev") == 0 || strcmp(path, "/dev/") == 0) {
+        memset(out, 0, sizeof(*out));
+        out->mode   = VFS_S_IFDIR | 0755;
+        out->uid    = 0;
+        out->gid    = 0;
+        out->is_dir = 1;
+        return 0;
+    }
+
+    const devfs_node_t *node = devfs_lookup(path);
+    if (!node) return -1;
+
+    memset(out, 0, sizeof(*out));
+    out->mode   = node->mode;
+    out->uid    = 0;
+    out->gid    = 0;
+    out->size   = 0;
+    out->is_dir = 0;
+    return 0;
+}
+
+static int devfs_readdir_cb(const char *path, vfs_dirent_t *out, int max) {
+    /* Only the root /dev directory is listable */
+    if (!out || max <= 0) return -1;
+    if (strcmp(path, "/dev") != 0 && strcmp(path, "/dev/") != 0) return -1;
+
+    int count = DEVFS_NODE_COUNT < max ? DEVFS_NODE_COUNT : max;
+    for (int i = 0; i < count; i++) {
+        memset(&out[i], 0, sizeof(out[i]));
+        strncpy(out[i].name, devfs_nodes[i].name, sizeof(out[i].name) - 1);
+        out[i].name[sizeof(out[i].name) - 1] = '\0';
+        out[i].size   = 0;
+        out[i].inode  = (uint32_t)(i + 1);
+        out[i].is_dir = 0;
+    }
+    return count;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+static filesystem_t devfs_vtable = {
+    .name     = "devfs",
+    .mount    = devfs_mount_cb,
+    .open     = devfs_open_cb,
+    .read     = devfs_read_cb,
+    .read_at  = devfs_read_at_cb,
+    .write    = devfs_write_cb,
+    .close    = devfs_close_cb,
+    .readdir  = devfs_readdir_cb,
+    .mkdir    = NULL,
+    .unlink   = NULL,
+    .stat     = devfs_stat_cb,
+    .link     = NULL,
+    .symlink  = NULL,
+    .readlink = NULL,
+    .chmod    = NULL,
+    .chown    = NULL,
+};
+
+filesystem_t *devfs_get_filesystem(void) {
+    return &devfs_vtable;
+}

--- a/fs/devfs.h
+++ b/fs/devfs.h
@@ -1,0 +1,15 @@
+#pragma once
+// BlueyOS devfs — "Bandit's Toolbelt"
+// An in-memory virtual filesystem mounted at /dev.
+// Provides synthesised device nodes (null, zero, random, tty, disks, …)
+// without requiring mknod or a writable root filesystem.
+//
+// Episode ref: "Dad Baby" — every tool has its place.
+// Bluey and all related characters are trademarks of Ludo Studio Pty Ltd,
+// licensed by BBC Studios. BlueyOS is an unofficial fan/research project.
+
+#include "vfs.h"
+
+// Return the filesystem_t vtable for devfs.  Register with vfs_register_fs()
+// before calling vfs_mount("/dev", "devfs", 0).
+filesystem_t *devfs_get_filesystem(void);

--- a/fs/fat.c
+++ b/fs/fat.c
@@ -24,7 +24,7 @@ static uint16_t   *fat_cache = NULL;    // in-memory FAT (up to 64KB FAT = 32K e
 static int         fat_loaded = 0;
 
 // Simple open file table for FAT
-#define FAT_MAX_OPEN 8
+#define FAT_MAX_OPEN 1024
 typedef struct {
     int      used;
     uint16_t first_cluster;

--- a/fs/procfs.c
+++ b/fs/procfs.c
@@ -4,7 +4,7 @@
 #include "../kernel/bootargs.h"
 #include "../lib/string.h"
 
-#define PROCFS_MAX_OPEN 8
+#define PROCFS_MAX_OPEN 1024
 #define PROCFS_NODE_NONE 0
 #define PROCFS_NODE_CMDLINE 1
 

--- a/fs/vfs.c
+++ b/fs/vfs.c
@@ -8,6 +8,7 @@
 #include "../lib/stdio.h"
 #include "../lib/string.h"
 #include "../kernel/devev.h"
+#include "../kernel/kheap.h"
 #include "../kernel/socket.h"
 #include "../kernel/tty.h"
 #include "vfs.h"
@@ -39,7 +40,10 @@ typedef struct {
     uint32_t offset;        // current seek position (for lseek / sequential reads)
 } vfs_fd_t;
 
-static vfs_fd_t fd_table[VFS_MAX_OPEN];
+static vfs_fd_t fd_table_static[VFS_MAX_OPEN];
+static vfs_fd_t *fd_table = fd_table_static;
+static int vfs_fd_capacity = VFS_MAX_OPEN;
+static int vfs_last_error = VFS_ERR_NONE;
 
 // Pipe buffer pool
 #define VFS_PIPE_BUF_SIZE 4096
@@ -56,6 +60,53 @@ typedef struct {
 } vfs_pipe_t;
 
 static vfs_pipe_t pipe_pool[VFS_MAX_PIPES];
+
+int vfs_get_last_error(void) {
+    return vfs_last_error;
+}
+
+static void vfs_set_last_error(int err) {
+    vfs_last_error = err;
+}
+
+static int vfs_effective_fd_limit(void) {
+    process_t *current = process_current();
+    uint32_t limit = current ? current->rlimit_nofile_cur : VFS_MAX_OPEN;
+
+    if (limit == 0xFFFFFFFFu || limit > (uint32_t)VFS_MAX_OPEN_HARD) {
+        limit = (uint32_t)VFS_MAX_OPEN_HARD;
+    }
+    if (limit < 3u) limit = 3u;
+    return (int)limit;
+}
+
+static int vfs_grow_fd_capacity(int min_capacity) {
+    int new_capacity = vfs_fd_capacity;
+    vfs_fd_t *new_table;
+
+    if (new_capacity <= 0) new_capacity = VFS_MAX_OPEN;
+    while (new_capacity < min_capacity) {
+        if (new_capacity >= VFS_MAX_OPEN_HARD) {
+            new_capacity = VFS_MAX_OPEN_HARD;
+            break;
+        }
+        new_capacity *= 2;
+        if (new_capacity > VFS_MAX_OPEN_HARD) new_capacity = VFS_MAX_OPEN_HARD;
+    }
+
+    if (new_capacity <= vfs_fd_capacity) return 0;
+
+    new_table = (vfs_fd_t*)kheap_alloc(sizeof(vfs_fd_t) * (size_t)new_capacity, 0);
+    if (!new_table) return 0;
+
+    memset(new_table, 0, sizeof(vfs_fd_t) * (size_t)new_capacity);
+    memcpy(new_table, fd_table, sizeof(vfs_fd_t) * (size_t)vfs_fd_capacity);
+
+    if (fd_table != fd_table_static) kheap_free(fd_table);
+    fd_table = new_table;
+    vfs_fd_capacity = new_capacity;
+    return 1;
+}
 
 // Allocate a free pipe slot; returns index or -1
 static int vfs_pipe_alloc(void) {
@@ -130,7 +181,13 @@ static int vfs_parent_path(const char *path, char *out, size_t out_len) {
 void vfs_init(void) {
     fs_count    = 0;
     mount_count = 0;
-    for (int i = 0; i < VFS_MAX_OPEN;   i++) fd_table[i].used = 0;
+    if (fd_table != fd_table_static) {
+        kheap_free(fd_table);
+        fd_table = fd_table_static;
+    }
+    vfs_fd_capacity = VFS_MAX_OPEN;
+    vfs_last_error = VFS_ERR_NONE;
+    for (int i = 0; i < vfs_fd_capacity; i++) fd_table[i].used = 0;
     for (int i = 0; i < VFS_MAX_MOUNTS; i++) {
         fs_registry[i] = NULL;
         mounts[i].active = 0;
@@ -238,10 +295,27 @@ static vfs_mount_t *vfs_find_mount(const char *path) {
 
 // Allocate a VFS file descriptor
 static int vfs_alloc_fd(void) {
-    for (int i = 3; i < VFS_MAX_OPEN; i++) {  // 0,1,2 = stdin/stdout/stderr
-        if (!fd_table[i].used) return i;
+    int limit = vfs_effective_fd_limit();
+
+    for (;;) {
+        int search_limit = vfs_fd_capacity < limit ? vfs_fd_capacity : limit;
+        for (int i = 3; i < search_limit; i++) {  // 0,1,2 = stdin/stdout/stderr
+            if (!fd_table[i].used) {
+                vfs_set_last_error(VFS_ERR_NONE);
+                return i;
+            }
+        }
+
+        if (search_limit >= limit) {
+            vfs_set_last_error(VFS_ERR_EMFILE);
+            return -1;
+        }
+
+        if (!vfs_grow_fd_capacity(limit)) {
+            vfs_set_last_error(VFS_ERR_ENFILE);
+            return -1;
+        }
     }
-    return -1;
 }
 
 int vfs_devev_open(void) {
@@ -260,7 +334,10 @@ int vfs_devev_open(void) {
 int vfs_socket_open(int socket_id) {
     int fd = vfs_alloc_fd();
     if (fd < 0) return -1;
-    if (socket_add_ref(socket_id) != 0) return -1;
+    if (socket_add_ref(socket_id) != 0) {
+        vfs_set_last_error(VFS_ERR_EBADF);
+        return -1;
+    }
 
     fd_table[fd].used = 1;
     fd_table[fd].fd_type = VFS_FD_TYPE_SOCKET;
@@ -273,18 +350,23 @@ int vfs_socket_open(int socket_id) {
 }
 
 int vfs_fd_is_devev(int fd) {
-    if (fd < 0 || fd >= VFS_MAX_OPEN || !fd_table[fd].used) return 0;
+    if (fd < 0 || fd >= vfs_fd_capacity || !fd_table[fd].used) return 0;
     return fd_table[fd].fd_type == VFS_FD_TYPE_DEVEV;
 }
 
 int vfs_fd_is_tty(int fd) {
-    if (fd < 0 || fd >= VFS_MAX_OPEN || !fd_table[fd].used) return 0;
+    if (fd < 0 || fd >= vfs_fd_capacity || !fd_table[fd].used) return 0;
     return fd_table[fd].fd_type == VFS_FD_TYPE_TTY;
 }
 
 int vfs_fd_is_socket(int fd) {
-    if (fd < 0 || fd >= VFS_MAX_OPEN || !fd_table[fd].used) return 0;
+    if (fd < 0 || fd >= vfs_fd_capacity || !fd_table[fd].used) return 0;
     return fd_table[fd].fd_type == VFS_FD_TYPE_SOCKET;
+}
+
+int vfs_fd_is_open(int fd) {
+    if (fd < 0 || fd >= vfs_fd_capacity) return 0;
+    return fd_table[fd].used;
 }
 
 int vfs_socket_id(int fd) {
@@ -295,6 +377,8 @@ int vfs_socket_id(int fd) {
 int vfs_open(const char *path, int flags) {
     int tty_kind;
     int fd;
+
+    vfs_set_last_error(VFS_ERR_NONE);
 
     if (!path) return -1;
 
@@ -406,7 +490,7 @@ int vfs_open(const char *path, int flags) {
 }
 
 int vfs_read(int fd, uint8_t *buf, size_t len) {
-    if (fd < 0 || fd >= VFS_MAX_OPEN || !fd_table[fd].used) return -1;
+    if (fd < 0 || fd >= vfs_fd_capacity || !fd_table[fd].used) return -1;
     if (fd_table[fd].fd_type == VFS_FD_TYPE_DEVEV)
         return devev_read_bytes(buf, len);
     if (fd_table[fd].fd_type == VFS_FD_TYPE_SOCKET)
@@ -444,7 +528,7 @@ int vfs_read(int fd, uint8_t *buf, size_t len) {
 }
 
 int vfs_read_at(int fd, uint8_t *buf, size_t len, uint32_t offset) {
-    if (fd < 0 || fd >= VFS_MAX_OPEN || !fd_table[fd].used) return -1;
+    if (fd < 0 || fd >= vfs_fd_capacity || !fd_table[fd].used) return -1;
     if (fd_table[fd].fd_type == VFS_FD_TYPE_DEVEV) return -1;
     if (fd_table[fd].fd_type == VFS_FD_TYPE_SOCKET) return -1;
     if (fd_table[fd].fd_type == VFS_FD_TYPE_TTY) return -1;
@@ -459,7 +543,7 @@ int vfs_read_at(int fd, uint8_t *buf, size_t len, uint32_t offset) {
 }
 
 int vfs_write(int fd, const uint8_t *buf, size_t len) {
-    if (fd < 0 || fd >= VFS_MAX_OPEN || !fd_table[fd].used) return -1;
+    if (fd < 0 || fd >= vfs_fd_capacity || !fd_table[fd].used) return -1;
     if (fd_table[fd].fd_type == VFS_FD_TYPE_SOCKET) {
         return socket_write(fd_table[fd].fs_fd, buf, len);
     }
@@ -499,7 +583,7 @@ int vfs_write(int fd, const uint8_t *buf, size_t len) {
 }
 
 int vfs_close(int fd) {
-    if (fd < 0 || fd >= VFS_MAX_OPEN || !fd_table[fd].used) return -1;
+    if (fd < 0 || fd >= vfs_fd_capacity || !fd_table[fd].used) return -1;
     if (fd_table[fd].fd_type == VFS_FD_TYPE_FILE) {
         vfs_mount_t *m = &mounts[fd_table[fd].fs_idx];
         if (m->fs->close) m->fs->close(fd_table[fd].fs_fd);
@@ -522,7 +606,7 @@ int vfs_close(int fd) {
 }
 
 int32_t vfs_lseek(int fd, int32_t offset, int whence) {
-    if (fd < 0 || fd >= VFS_MAX_OPEN || !fd_table[fd].used) return -1;
+    if (fd < 0 || fd >= vfs_fd_capacity || !fd_table[fd].used) return -1;
     if (fd_table[fd].fd_type != VFS_FD_TYPE_FILE) return -1;
 
     uint32_t new_offset;
@@ -549,7 +633,10 @@ int32_t vfs_lseek(int fd, int32_t offset, int whence) {
 }
 
 int vfs_dup(int oldfd) {
-    if (oldfd < 0 || oldfd >= VFS_MAX_OPEN || !fd_table[oldfd].used) return -1;
+    if (oldfd < 0 || oldfd >= vfs_fd_capacity || !fd_table[oldfd].used) {
+        vfs_set_last_error(VFS_ERR_EBADF);
+        return -1;
+    }
     int newfd = vfs_alloc_fd();
     if (newfd < 0) return -1;
     fd_table[newfd] = fd_table[oldfd];
@@ -566,12 +653,25 @@ int vfs_dup(int oldfd) {
                 pipe_pool[pipe_idx].read_refcount++;
         }
     }
+    vfs_set_last_error(VFS_ERR_NONE);
     return newfd;
 }
 
 int vfs_dup2(int oldfd, int newfd) {
-    if (oldfd < 0 || oldfd >= VFS_MAX_OPEN || !fd_table[oldfd].used) return -1;
-    if (newfd < 0 || newfd >= VFS_MAX_OPEN) return -1;
+    int limit = vfs_effective_fd_limit();
+
+    if (oldfd < 0 || oldfd >= vfs_fd_capacity || !fd_table[oldfd].used) {
+        vfs_set_last_error(VFS_ERR_EBADF);
+        return -1;
+    }
+    if (newfd < 0 || newfd >= limit) {
+        vfs_set_last_error(VFS_ERR_EBADF);
+        return -1;
+    }
+    if (newfd >= vfs_fd_capacity && !vfs_grow_fd_capacity(newfd + 1)) {
+        vfs_set_last_error(VFS_ERR_ENFILE);
+        return -1;
+    }
     if (oldfd == newfd) return newfd;
     if (fd_table[newfd].used) vfs_close(newfd);
     fd_table[newfd] = fd_table[oldfd];
@@ -588,12 +688,18 @@ int vfs_dup2(int oldfd, int newfd) {
                 pipe_pool[pipe_idx].read_refcount++;
         }
     }
+    vfs_set_last_error(VFS_ERR_NONE);
     return newfd;
 }
 
 int vfs_pipe(int fds[2]) {
+    vfs_set_last_error(VFS_ERR_NONE);
+
     int pipe_idx = vfs_pipe_alloc();
-    if (pipe_idx < 0) return -1;
+    if (pipe_idx < 0) {
+        vfs_set_last_error(VFS_ERR_ENFILE);
+        return -1;
+    }
 
     int rfd = vfs_alloc_fd();
     if (rfd < 0) { pipe_pool[pipe_idx].used = 0; return -1; }
@@ -628,19 +734,31 @@ int vfs_pipe(int fds[2]) {
 
     fds[0] = rfd;
     fds[1] = wfd;
+    vfs_set_last_error(VFS_ERR_NONE);
     return 0;
 }
 
 const char *vfs_fd_get_path(int fd) {
-    if (fd < 0 || fd >= VFS_MAX_OPEN || !fd_table[fd].used) return NULL;
+    if (fd < 0 || fd >= vfs_fd_capacity || !fd_table[fd].used) return NULL;
     if (fd_table[fd].fd_type != VFS_FD_TYPE_FILE) return NULL;
     return fd_table[fd].path;
 }
 
 /* Allocate the lowest free fd >= min_fd; used for F_DUPFD semantics */
 int vfs_dup_above(int oldfd, int min_fd) {
-    if (oldfd < 0 || oldfd >= VFS_MAX_OPEN || !fd_table[oldfd].used) return -1;
-    for (int i = min_fd; i < VFS_MAX_OPEN; i++) {
+    int limit = vfs_effective_fd_limit();
+
+    if (oldfd < 0 || oldfd >= vfs_fd_capacity || !fd_table[oldfd].used) {
+        vfs_set_last_error(VFS_ERR_EBADF);
+        return -1;
+    }
+    if (min_fd < 0 || min_fd >= limit) {
+        vfs_set_last_error(VFS_ERR_EMFILE);
+        return -1;
+    }
+    if (limit > vfs_fd_capacity) vfs_grow_fd_capacity(limit);
+
+    for (int i = min_fd; i < limit && i < vfs_fd_capacity; i++) {
         if (!fd_table[i].used) {
             fd_table[i] = fd_table[oldfd];
             if (fd_table[i].fd_type == VFS_FD_TYPE_SOCKET) {
@@ -655,9 +773,11 @@ int vfs_dup_above(int oldfd, int min_fd) {
                         pipe_pool[pipe_idx].read_refcount++;
                 }
             }
+            vfs_set_last_error(VFS_ERR_NONE);
             return i;
         }
     }
+    vfs_set_last_error(VFS_ERR_EMFILE);
     return -1; /* EMFILE */
 }
 
@@ -782,7 +902,7 @@ int vfs_stat(const char *path, vfs_stat_t *out) {
 }
 
 int vfs_fstat(int fd, vfs_stat_t *out) {
-    if (fd < 0 || fd >= VFS_MAX_OPEN) return -1;
+    if (fd < 0 || fd >= vfs_fd_capacity) return -1;
     if (!fd_table[fd].used) return -1;
     if (!out) return -1;
     if (fd_table[fd].fd_type == VFS_FD_TYPE_SOCKET) {
@@ -868,7 +988,7 @@ int vfs_chmod(const char *path, uint16_t mode) {
 }
 
 int vfs_fchmod(int fd, uint16_t mode) {
-    if (fd < 0 || fd >= VFS_MAX_OPEN || !fd_table[fd].used) return -1;
+    if (fd < 0 || fd >= vfs_fd_capacity || !fd_table[fd].used) return -1;
     const char *path = fd_table[fd].path;
     if (!path || !path[0]) return -1;
     return vfs_chmod(path, mode);
@@ -896,7 +1016,7 @@ int vfs_lchown(const char *path, uint32_t uid, uint32_t gid) {
 }
 
 int vfs_fchown(int fd, uint32_t uid, uint32_t gid) {
-    if (fd < 0 || fd >= VFS_MAX_OPEN || !fd_table[fd].used) return -1;
+    if (fd < 0 || fd >= vfs_fd_capacity || !fd_table[fd].used) return -1;
     const char *path = fd_table[fd].path;
     if (!path || !path[0]) return -1;
     return vfs_chown(path, uid, gid);

--- a/fs/vfs.h
+++ b/fs/vfs.h
@@ -8,8 +8,14 @@
 
 #define VFS_MAX_MOUNTS   8
 #define VFS_MAX_OPEN     32
+#define VFS_MAX_OPEN_HARD 4096
 #define VFS_NAME_LEN     64
 #define VFS_PATH_LEN     256
+
+#define VFS_ERR_NONE   0
+#define VFS_ERR_EBADF  9
+#define VFS_ERR_ENFILE 23
+#define VFS_ERR_EMFILE 24
 
 // Open flags (POSIX-compatible)
 #define VFS_O_RDONLY  0
@@ -24,6 +30,7 @@
 #define VFS_S_IFREG  0x8000
 #define VFS_S_IFDIR  0x4000
 #define VFS_S_IFCHR  0x2000
+#define VFS_S_IFBLK  0x6000
 #define VFS_S_ISUID  04000
 #define VFS_S_ISGID  02000
 #define VFS_S_IRUSR  0400
@@ -115,7 +122,9 @@ int  vfs_socket_open(int socket_id); // attach a kernel socket to a VFS fd
 int  vfs_fd_is_devev(int fd);        // 1 if the fd is a device event channel
 int  vfs_fd_is_tty(int fd);          // 1 if the fd is a tty/console device
 int  vfs_fd_is_socket(int fd);       // 1 if the fd is a socket endpoint
+int  vfs_fd_is_open(int fd);         // 1 if descriptor exists and is open
 int  vfs_socket_id(int fd);          // backend socket id for a socket fd
+int  vfs_get_last_error(void);       // last VFS fd-allocation related errno code
 int  vfs_read(int fd, uint8_t *buf, size_t len);
 int  vfs_read_at(int fd, uint8_t *buf, size_t len, uint32_t offset);
 int  vfs_write(int fd, const uint8_t *buf, size_t len);

--- a/grub.cfg
+++ b/grub.cfg
@@ -12,13 +12,13 @@ set default=0
 
 menuentry "BlueyOS - It's a big day!" {
     set gfxpayload=text
-    multiboot /boot/blueyos.elf root=/dev/hda2 rootfstype=blueyfs
+    multiboot /boot/blueyos.elf root=/dev/disk0s2 rootfstype=blueyfs
     boot
 }
 
 menuentry "BlueyOS - Safe Mode (No Rules, No Fun)" {
     set gfxpayload=text
-    multiboot /boot/blueyos.elf safe root=/dev/hda2 rootfstype=blueyfs
+    multiboot /boot/blueyos.elf safe root=/dev/disk0s2 rootfstype=blueyfs
     boot
 }
 

--- a/include/rlimit.h
+++ b/include/rlimit.h
@@ -8,3 +8,4 @@ typedef struct {
 } rlimit_t;
 
 #define RLIMIT_STACK 3
+#define RLIMIT_NOFILE 7

--- a/kernel/elf.c
+++ b/kernel/elf.c
@@ -170,9 +170,10 @@ static int elf_copy_string(char **stack_ptr, uint32_t stack_base, const char *va
     return 0;
 }
 
-int elf_validate(const uint8_t *data, size_t len) {
+int elf_validate(const uint8_t *data, size_t len, const char *name) {
+    const char *n = (name && name[0]) ? name : "(unknown)";
     if (len < sizeof(elf32_ehdr_t)) {
-        kprintf("[ELF] Too small to be an ELF file\n");
+        kprintf("[ELF] Too small to be an ELF file: %s\n", n);
         return -1;
     }
     const elf32_ehdr_t *hdr = (const elf32_ehdr_t*)data;
@@ -182,29 +183,29 @@ int elf_validate(const uint8_t *data, size_t len) {
         hdr->e_ident[1] != 'E'  ||
         hdr->e_ident[2] != 'L'  ||
         hdr->e_ident[3] != 'F') {
-        kprintf("[ELF] Invalid magic - that's not an ELF!\n");
+        kprintf("[ELF] Invalid magic - not an ELF: %s\n", n);
         return -1;
     }
     // 32-bit ELF only (class = 1)
     if (hdr->e_ident[4] != 1) {
-        kprintf("[ELF] Not a 32-bit ELF\n");
+        kprintf("[ELF] Not a 32-bit ELF: %s\n", n);
         return -1;
     }
     // Must be executable
     if (hdr->e_type != ET_EXEC) {
-        kprintf("[ELF] Not an executable ELF (type=%d)\n", hdr->e_type);
+        kprintf("[ELF] Not an executable ELF (type=%d): %s\n", hdr->e_type, n);
         return -1;
     }
     // Must be x86
     if (hdr->e_machine != EM_386) {
-        kprintf("[ELF] Not an x86 ELF (machine=%d)\n", hdr->e_machine);
+        kprintf("[ELF] Not an x86 ELF (machine=%d): %s\n", hdr->e_machine, n);
         return -1;
     }
     return 0;
 }
 
 int elf_load(const uint8_t *data, size_t len, uint32_t *entry_out) {
-    if (elf_validate(data, len) != 0) return -1;
+    if (elf_validate(data, len, NULL) != 0) return -1;
 
     const elf32_ehdr_t *hdr = (const elf32_ehdr_t*)data;
 
@@ -372,7 +373,7 @@ static int elf_load_into_address_space(uint32_t page_dir,
     uint32_t loaded = 0;
     uint32_t image_end = 0;
 
-    if (elf_validate(data, len) != 0) return -1;
+    if (elf_validate(data, len, NULL) != 0) return -1;
 
     hdr = (const elf32_ehdr_t*)data;
     paging_switch_directory(page_dir);
@@ -439,7 +440,8 @@ static int elf_load_into_address_space(uint32_t page_dir,
 }
 
 int elf_stream_load_into_address_space(uint32_t page_dir, int fd, size_t file_len,
-                                       uint32_t *entry_out, uint32_t *image_end_out) {
+                                       uint32_t *entry_out, uint32_t *image_end_out,
+                                       const char *name) {
     uint32_t old_page_dir = paging_current_directory();
     elf32_ehdr_t hdr;
     elf32_phdr_t *phdrs = NULL;
@@ -453,7 +455,7 @@ int elf_stream_load_into_address_space(uint32_t page_dir, int fd, size_t file_le
         return -1;
     }
 
-    if (elf_validate((const uint8_t*)&hdr, sizeof(hdr)) != 0) return -1;
+    if (elf_validate((const uint8_t*)&hdr, sizeof(hdr), name) != 0) return -1;
 
     /* Read program headers */
     ph_size = (size_t)hdr.e_phnum * hdr.e_phentsize;
@@ -603,7 +605,8 @@ int elf_load_image(const char *path, const char *const argv[], const char *const
 
     if (elf_stream_load_into_address_space(page_dir, fd, (size_t)file_len,
                                            &image_out->entry,
-                                           &image_out->image_end) != 0) {
+                                           &image_out->image_end,
+                                           path) != 0) {
         vfs_close(fd);
         paging_destroy_address_space(page_dir);
         return -1;

--- a/kernel/elf.c
+++ b/kernel/elf.c
@@ -15,9 +15,9 @@
 #define ELF_READ_CHUNK_SIZE   512u
 #define ELF_MAX_IMAGE_SIZE    (1024u * 1024u)
 #define ELF_USER_STACK_BASE   0x70000000u
-#define ELF_USER_STACK_SIZE   (1024u * 1024u)
+#define ELF_USER_STACK_SIZE   (8u * 1024u * 1024u)   /* 8 MiB soft limit, matching Linux default */
 #define ELF_USER_STACK_PREFAULT_PAGES 4u
-#define ELF_USER_STACK_STRIDE 0x00200000u
+#define ELF_USER_STACK_STRIDE 0x00A00000u             /* 10 MiB between process stacks */
 
 static uint32_t elf_next_stack_base = ELF_USER_STACK_BASE;
 

--- a/kernel/elf.h
+++ b/kernel/elf.h
@@ -58,7 +58,7 @@ typedef struct __attribute__((packed)) {
 
 // Returns 0 on success, -1 on error. Sets *entry_out to entry point.
 int elf_load(const uint8_t *data, size_t len, uint32_t *entry_out);
-int elf_validate(const uint8_t *data, size_t len);
+int elf_validate(const uint8_t *data, size_t len, const char *name);
 int elf_build_initial_stack(uint32_t page_dir,
                             const char *const argv[], const char *const envp[],
                             uint32_t *stack_base_out, uint32_t *stack_top_out,

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -53,6 +53,7 @@
 #include "../fs/fat.h"
 #include "../fs/blueyfs.h"
 #include "../fs/procfs.h"
+#include "../fs/devfs.h"
 #include "../net/tcpip.h"
 #include "../shell/shell.h"
 #include "syslog.h"
@@ -224,6 +225,13 @@ void kernel_main(uint32_t magic, uint32_t *mboot_info) {
     vfs_register_fs(fat_get_filesystem());
     vfs_register_fs(biscuitfs_get_filesystem());
     vfs_register_fs(procfs_get_filesystem());
+    vfs_register_fs(devfs_get_filesystem());
+
+    // Mount /dev immediately — before any ATA/root so device nodes are
+    // available even in diskless boot.
+    if (vfs_mount("/dev", "devfs", 0) != 0) {
+        kprintf("[VFS]  Failed to mount devfs at /dev\n");
+    }
 
     // Step 11: ATA disk driver (module)
     if (module_load("ata") == 0) {

--- a/kernel/paging.c
+++ b/kernel/paging.c
@@ -254,7 +254,7 @@ void paging_map_in_directory(uint32_t page_dir_phys, uint32_t virt, uint32_t phy
      * the currently-active address space.  A full CR3 reload is unnecessary
      * and flushes all global entries. */
     if (page_dir == current_page_dir) {
-        __asm__ volatile("invlpg (%0)" : : "r"(virt) : "memory");
+        paging_invlpg(virt);
     }
 }
 

--- a/kernel/paging.c
+++ b/kernel/paging.c
@@ -108,83 +108,98 @@ void page_fault_handler(registers_t *regs) {
 
     if (!regs) return;
 
-    kprintf("\n[PGF]  Page Fault! Faulting address: 0x%x\n", faulting_addr);
+    /* Attempt grow-on-demand for user stack faults BEFORE printing anything.
+     * If the fault is a normal stack-growth event we return silently so the
+     * kernel log stays clean. */
+    process_t *proc = process_current();
+    uint32_t page_aligned = faulting_addr & ~0xFFFu;
+
+    if (proc && (regs->err_code & 0x4) && proc->page_dir &&
+        !(regs->err_code & 0x1)) {  /* not-present fault only */
+        /* Stack grows downward. Allow on-demand mapping for pages within the
+         * reserved stack region, but do not map the bottom-most guard page. */
+        uint32_t stack_base = proc->user_stack_base;
+        uint32_t stack_top  = proc->user_stack_top;
+        if (faulting_addr >= stack_base + PAGE_SIZE && faulting_addr < stack_top) {
+            uint32_t offset_from_top = stack_top - page_aligned;
+            if (offset_from_top <= proc->rlimit_stack_cur) {
+                uint32_t phys = pmm_alloc_frame();
+                if (!phys) {
+                    /* Fall through to fatal handling below. */
+                    goto fatal_fault;
+                }
+                paging_map_in_directory(proc->page_dir, page_aligned, phys,
+                                        PAGE_PRESENT | PAGE_WRITABLE | PAGE_USER);
+                memset((void*)page_aligned, 0, PAGE_SIZE);
+                if (proc->tls_base) regs->gs = GDT_TLS_SEL;
+                else if (!regs->gs) regs->gs = GDT_USER_DATA;
+                return; /* silently handled: no [PGF] spam */
+            }
+        }
+    }
+
+fatal_fault:
+    /* Only now print the fault details — this is a real problem. */
+    kprintf("\n[PGF]  Page Fault! pid=%u '%s' faulting_addr=0x%08x EIP=0x%08x\n",
+            proc ? proc->pid : 0u,
+            proc ? proc->name : "?",
+            faulting_addr, regs->eip);
     kprintf("[PGF]  Error code: 0x%x (", regs->err_code);
     if (regs->err_code & 0x1) kprintf("protection violation"); else kprintf("not present");
     if (regs->err_code & 0x2) kprintf(", write");  else kprintf(", read");
     if (regs->err_code & 0x4) kprintf(", user");   else kprintf(", supervisor");
-    kprintf(")\n[PGF]  EIP: 0x%x\n", regs->eip);
+    kprintf(")\n");
 
-    /* Extra diagnostic dump when EIP is in the low-address null region —
-     * these faults often indicate a corrupted code pointer (e.g. EIP set to
-     * a segment selector value such as 0x33).  Emit a full register frame
-     * so the developer can correlate with the signal/scheduling logs. */
-    if (regs->eip < 0x1000 && syslog_get_verbose() >= VERBOSE_INFO) {
-        process_t *dbg_proc = process_current();
-        kprintf("[PGF]  *** Low-address EIP fault (likely corrupted code pointer) ***\n");
+    /* Always dump registers for fatal user faults so we can diagnose the
+     * root cause (corrupted EIP, stack overflow, etc.) without needing to
+     * increase the verbose level. */
+    if (regs->err_code & 0x4) {
         kprintf("[PGF]  EAX=0x%08x EBX=0x%08x ECX=0x%08x EDX=0x%08x\n",
                 regs->eax, regs->ebx, regs->ecx, regs->edx);
         kprintf("[PGF]  ESI=0x%08x EDI=0x%08x EBP=0x%08x ESP=0x%08x\n",
                 regs->esi, regs->edi, regs->ebp, regs->useresp);
         kprintf("[PGF]  CS=0x%04x DS=0x%04x GS=0x%04x EFLAGS=0x%08x\n",
                 regs->cs, regs->ds, regs->gs, regs->eflags);
-        if (dbg_proc) {
-            kprintf("[PGF]  pid=%u uid=%u euid=%u name=%s tls_base=0x%08x\n",
-                    dbg_proc->pid, dbg_proc->uid, dbg_proc->euid,
-                    dbg_proc->name, dbg_proc->tls_base);
-        }
+        if (proc)
+            kprintf("[PGF]  stack_base=0x%08x stack_top=0x%08x rlimit=0x%08x vfork=%u\n",
+                    proc->user_stack_base, proc->user_stack_top,
+                    proc->rlimit_stack_cur,
+                    (proc->flags & PROC_FLAG_VFORK_SHARED_VM) ? 1u : 0u);
     }
 
-    /* Attempt grow-on-demand for user stack faults. */
-    process_t *proc = process_current();
-    uint32_t page_aligned = faulting_addr & ~0xFFFu;
+    /* Supervisor-mode fault (should never happen after kernel stabilises). */
+    if (!(regs->err_code & 0x4)) {
+        kprintf("[PGF]  Supervisor fault — halting.\n");
+        __asm__ volatile("cli; hlt");
+        for(;;);
+    }
 
-    if (proc && (regs->err_code & 0x4) && proc->page_dir) {
-        /* Stack grows downward. Allow on-demand mapping for pages within the
-         * reserved stack region, but do not map the bottom-most guard page. */
-        uint32_t stack_base = proc->user_stack_base;
-        uint32_t stack_top = proc->user_stack_top;
-        if (faulting_addr >= stack_base + PAGE_SIZE && faulting_addr < stack_top) {
-            uint32_t offset_from_top = stack_top - page_aligned;
-            if (offset_from_top <= proc->rlimit_stack_cur) {
-                /* Map this page on behalf of the process. */
-                uint32_t phys = pmm_alloc_frame();
-                if (!phys) {
-                    kprintf("[PGF]  Out of physical frames while growing stack for pid=%u\n", proc->pid);
-                    /* Do NOT return here: the faulting instruction would be
-                     * retried, causing an infinite fault loop.  Mark the
-                     * process as exited (SIGSEGV) and halt until the
-                     * scheduler context-switches away. */
-                    process_mark_exited(proc, 128 + SIGSEGV);
-                    __asm__ volatile("sti");
-                    for (;;) __asm__ volatile("hlt");
-                }
-                if (syslog_get_verbose() >= VERBOSE_INFO)
-                    kprintf("[PGF]  Growing user stack: pid=%u va=0x%08x -> phys=0x%08x\n",
-                            proc->pid, page_aligned, phys);
-                /* Map the page into the process address space.  The fault always
-                 * happens in the context of the current process, so proc->page_dir
-                 * is the active directory.  paging_map_in_directory emits invlpg
-                 * for us since the target dir is the current one; we can then
-                 * zero the page directly without a context switch. */
-                paging_map_in_directory(proc->page_dir, page_aligned, phys,
-                                        PAGE_PRESENT | PAGE_WRITABLE | PAGE_USER);
-                memset((void*)page_aligned, 0, PAGE_SIZE);
-                if (proc->tls_base) regs->gs = GDT_TLS_SEL;
-                else if (!regs->gs) regs->gs = GDT_USER_DATA;
-                return; /* return to userland; instruction will be retried */
-            }
-        }
-        /* Fault in user mode but outside allowed stack growth: send SIGSEGV */
-        kprintf("[PGF]  User fault outside stack growth region pid=%u addr=0x%08x usesp=0x%08x\n",
-                proc->pid, faulting_addr, regs->useresp);
-        process_mark_exited(proc, SIGSEGV);
-        /* Enable interrupts and halt; the timer IRQ will context-switch away. */
+    /* User-mode protectio-violation in kernel-mapped page: definitely fatal. */
+    if (regs->err_code & 0x1) {
+        kprintf("[PGF]  Protection violation in user process pid=%u — SIGSEGV\n",
+                proc ? proc->pid : 0u);
+        if (proc) process_mark_exited(proc, 128 + SIGSEGV);
         __asm__ volatile("sti");
         for(;;) __asm__ volatile("hlt");
     }
 
-    kprintf("[PGF]  Bandit forgot to map that page! Halting.\n");
+    /* Not-present user fault outside the allowed grow region. */
+    if (proc) {
+        kprintf("[PGF]  User not-present fault outside stack region pid=%u — SIGSEGV\n",
+                proc->pid);
+        if (!proc->page_dir) {
+            kprintf("[PGF]  No page directory! Halting.\n");
+            __asm__ volatile("cli; hlt");
+            for(;;);
+        }
+        /* Try to handle PMM OOM reported from the growth path above. */
+        kprintf("[PGF]  Out of physical frames (pid=%u) — SIGSEGV\n", proc->pid);
+        process_mark_exited(proc, 128 + SIGSEGV);
+        __asm__ volatile("sti");
+        for(;;) __asm__ volatile("hlt");
+    }
+
+    kprintf("[PGF]  Unhandled supervisor not-present fault — halting.\n");
     __asm__ volatile("cli; hlt");
     for(;;);
 }

--- a/kernel/paging.c
+++ b/kernel/paging.c
@@ -162,13 +162,14 @@ void page_fault_handler(registers_t *regs) {
                 if (syslog_get_verbose() >= VERBOSE_INFO)
                     kprintf("[PGF]  Growing user stack: pid=%u va=0x%08x -> phys=0x%08x\n",
                             proc->pid, page_aligned, phys);
+                /* Map the page into the process address space.  The fault always
+                 * happens in the context of the current process, so proc->page_dir
+                 * is the active directory.  paging_map_in_directory emits invlpg
+                 * for us since the target dir is the current one; we can then
+                 * zero the page directly without a context switch. */
                 paging_map_in_directory(proc->page_dir, page_aligned, phys,
                                         PAGE_PRESENT | PAGE_WRITABLE | PAGE_USER);
-                /* Zero the newly mapped page in the process address space. */
-                uint32_t old_dir = paging_current_directory();
-                paging_switch_directory(proc->page_dir);
                 memset((void*)page_aligned, 0, PAGE_SIZE);
-                paging_switch_directory(old_dir);
                 if (proc->tls_base) regs->gs = GDT_TLS_SEL;
                 else if (!regs->gs) regs->gs = GDT_USER_DATA;
                 return; /* return to userland; instruction will be retried */
@@ -234,10 +235,11 @@ void paging_map_in_directory(uint32_t page_dir_phys, uint32_t virt, uint32_t phy
 
     page_table[pt_idx] = new_entry;
 
+    /* Use invlpg to shoot down only this TLB entry when the mapping is in
+     * the currently-active address space.  A full CR3 reload is unnecessary
+     * and flushes all global entries. */
     if (page_dir == current_page_dir) {
-        paging_refresh_active_directory(page_dir);
-    } else if (old_entry & PAGE_PRESENT) {
-        paging_refresh_active_directory(page_dir);
+        __asm__ volatile("invlpg (%0)" : : "r"(virt) : "memory");
     }
 }
 

--- a/kernel/paging.h
+++ b/kernel/paging.h
@@ -42,3 +42,9 @@ int      paging_unmap_in_directory(uint32_t page_dir_phys, uint32_t virt);
 // `flags` should contain PAGE_WRITABLE / PAGE_USER as desired; PAGE_PRESENT
 // is preserved by the implementation. Returns 0 on success, -1 on failure.
 int      paging_set_page_flags_in_directory(uint32_t page_dir_phys, uint32_t virt, uint32_t flags);
+
+// Invalidate a single TLB entry for the given virtual address in the current
+// address space.  Much cheaper than a full CR3 reload for point mappings.
+static inline void paging_invlpg(uint32_t virt) {
+    __asm__ volatile("invlpg (%0)" : : "r"(virt) : "memory");
+}

--- a/kernel/process.c
+++ b/kernel/process.c
@@ -572,8 +572,7 @@ void process_exit(int code) {
     process_mark_exited(dying, code);
     kprintf("[PRC]  Process '%s' (pid=%d) exited with code %d\n",
             dying->name, dying->pid, code);
-    /* Yield immediately so the zombie doesn't keep running in userspace. */
-    scheduler_yield();
+    /* The process is now a zombie; rescheduling occurs on trap return. */
 }
 
 process_t *process_current(void) { return proc_current; }

--- a/kernel/process.c
+++ b/kernel/process.c
@@ -22,6 +22,9 @@
 #define BLUEY_ENOMEM 12
 #define BLUEY_EPERM   1
 
+#define PROCESS_RLIMIT_NOFILE_DEFAULT_CUR 256u
+#define PROCESS_RLIMIT_NOFILE_DEFAULT_MAX 1024u
+
 #define PROCESS_USER_MMAP_BASE 0x50000000u
 
 static process_t *proc_list  = NULL;   // head of process linked list
@@ -81,6 +84,9 @@ static void process_set_credentials(process_t *process, uint32_t uid, uint32_t g
             process->group_count = 1;
         }
     }
+
+    process->rlimit_nofile_cur = PROCESS_RLIMIT_NOFILE_DEFAULT_CUR;
+    process->rlimit_nofile_max = PROCESS_RLIMIT_NOFILE_DEFAULT_MAX;
 }
 
 static void process_init_kernel_frame(process_t *process, uint32_t entry) {
@@ -153,6 +159,13 @@ static void process_enqueue_deferred_reap(process_t *process) {
 static int process_wait_matches(process_t *parent, process_t *child) {
     if (!parent || !child) return 0;
     if (parent->state != PROC_WAITING) return 0;
+    /* If the parent is blocked waiting for a vfork child (vfork_child_pid != 0),
+     * do NOT wake it via the normal waitpid-style path.  The parent is only
+     * released when the specific vfork child calls exec() or _exit(), which
+     * goes through process_release_vfork_parent().  Waking the parent early
+     * lets it run concurrently with its live vfork child, corrupting the
+     * shared address space (stack, fd table, etc.). */
+    if (parent->vfork_child_pid != 0) return 0;
     if (parent->wait_pid > 0 && parent->wait_pid != (int32_t)child->pid) return 0;
     return child->parent_pid == parent->pid;
 }
@@ -362,6 +375,8 @@ process_t *process_fork_current(const registers_t *regs, int32_t *error_out) {
     child->user_stack_top = parent->user_stack_top;
     child->rlimit_stack_cur = parent->rlimit_stack_cur;
     child->rlimit_stack_max = parent->rlimit_stack_max;
+    child->rlimit_nofile_cur = parent->rlimit_nofile_cur;
+    child->rlimit_nofile_max = parent->rlimit_nofile_max;
     child->tls_base = parent->tls_base;
     child->page_dir = page_dir;
     child->brk_base = parent->brk_base;
@@ -429,6 +444,8 @@ process_t *process_vfork_current(const registers_t *regs, int32_t *error_out) {
     child->user_stack_top = parent->user_stack_top;
     child->rlimit_stack_cur = parent->rlimit_stack_cur;
     child->rlimit_stack_max = parent->rlimit_stack_max;
+    child->rlimit_nofile_cur = parent->rlimit_nofile_cur;
+    child->rlimit_nofile_max = parent->rlimit_nofile_max;
     child->tls_base = parent->tls_base;
     child->page_dir = parent->page_dir;
     child->brk_base = parent->brk_base;
@@ -539,17 +556,24 @@ void process_mark_exited(process_t *process, int code) {
         signal_send_pid(parent->pid, SIGCHLD);
         if (process_wait_matches(parent, process)) {
             process_complete_wait(parent, process, 0);
-        } else if (parent->state == PROC_WAITING) {
+        } else if (parent->state == PROC_WAITING && parent->vfork_child_pid == 0) {
+            /* Wake the parent only if it is not blocked for a vfork child.
+             * Vfork-waiting parents are released exclusively through
+             * process_release_vfork_parent(). */
             parent->state = PROC_READY;
         }
     }
 }
 
 void process_exit(int code) {
+    process_t *dying;
     if (!proc_current) return;
-    process_mark_exited(proc_current, code);
+    dying = proc_current;
+    process_mark_exited(dying, code);
     kprintf("[PRC]  Process '%s' (pid=%d) exited with code %d\n",
-            proc_current->name, proc_current->pid, code);
+            dying->name, dying->pid, code);
+    /* Yield immediately so the zombie doesn't keep running in userspace. */
+    scheduler_yield();
 }
 
 process_t *process_current(void) { return proc_current; }

--- a/kernel/process.h
+++ b/kernel/process.h
@@ -57,6 +57,7 @@ typedef struct process {
     /* CPU accounting: cumulative ticks and last-start tick for this process/thread */
     uint32_t      cpu_ticks;     /* accumulated timer ticks spent on CPU */
     uint32_t      cpu_last_tick; /* tick value when this process was scheduled in */
+    uint64_t      vruntime;      /* CFS virtual runtime (weighted tick accumulator) */
     int           exit_code;
     uint32_t      sleep_until;   // timer tick to wake at (0 = not sleeping)
     uint32_t      priority;      // 1 (low) .. 10 (high) - Bluey always gets priority :)

--- a/kernel/process.h
+++ b/kernel/process.h
@@ -40,6 +40,8 @@ typedef struct process {
     uint32_t      user_stack_limit; // soft limit for stack growth (grow-on-demand)
     uint32_t      rlimit_stack_cur;
     uint32_t      rlimit_stack_max;
+    uint32_t      rlimit_nofile_cur;
+    uint32_t      rlimit_nofile_max;
     uint32_t      tls_base;          // thread-local storage base for GDT entry 6
     uint32_t      robust_list_head;  // userspace head for set_robust_list(2)
     uint32_t      robust_list_len;

--- a/kernel/rootfs.c
+++ b/kernel/rootfs.c
@@ -25,7 +25,8 @@ static bool rootfs_map_device_lba(const char *device, uint32_t *start_lba) {
         return true;
     }
 
-    if (strcmp(device, "/dev/hda") == 0 ||
+    if (strcmp(device, "/dev/disk0") == 0 ||
+        strcmp(device, "/dev/hda") == 0 ||
         strcmp(device, "/dev/hda0") == 0 ||
         strcmp(device, "/dev/sda") == 0 ||
         strcmp(device, "/dev/sda0") == 0 ||
@@ -35,21 +36,24 @@ static bool rootfs_map_device_lba(const char *device, uint32_t *start_lba) {
         return true;
     }
 
-    if (strcmp(device, "/dev/hda1") == 0 ||
+    if (strcmp(device, "/dev/disk0s1") == 0 ||
+        strcmp(device, "/dev/hda1") == 0 ||
         strcmp(device, "/dev/sda1") == 0 ||
         strcmp(device, "/dev/ata0p1") == 0) {
         *start_lba = BLUEYOS_BOOT_PARTITION_LBA;
         return true;
     }
 
-    if (strcmp(device, "/dev/hda2") == 0 ||
+    if (strcmp(device, "/dev/disk0s2") == 0 ||
+        strcmp(device, "/dev/hda2") == 0 ||
         strcmp(device, "/dev/sda2") == 0 ||
         strcmp(device, "/dev/ata0p2") == 0) {
         *start_lba = BLUEYOS_ROOT_PARTITION_LBA;
         return true;
     }
 
-    if (strcmp(device, "/dev/hda3") == 0 ||
+    if (strcmp(device, "/dev/disk0s3") == 0 ||
+        strcmp(device, "/dev/hda3") == 0 ||
         strcmp(device, "/dev/sda3") == 0 ||
         strcmp(device, "/dev/ata0p3") == 0) {
         *start_lba = BLUEYOS_SWAP_PARTITION_LBA;
@@ -63,7 +67,7 @@ void rootfs_config_init(rootfs_config_t *cfg) {
     if (!cfg) return;
 
     memset(cfg, 0, sizeof(*cfg));
-    strncpy(cfg->device, "/dev/hda2", sizeof(cfg->device) - 1);
+    strncpy(cfg->device, "/dev/disk0s2", sizeof(cfg->device) - 1);
     strncpy(cfg->fs_name, "biscuitfs", sizeof(cfg->fs_name) - 1);
     cfg->start_lba = BLUEYOS_ROOT_PARTITION_LBA;
     cfg->auto_probe = true;

--- a/kernel/scheduler.c
+++ b/kernel/scheduler.c
@@ -1,4 +1,4 @@
-// BlueyOS Round-Robin Scheduler
+// BlueyOS CFS Scheduler
 // "Bandit's Homework Scheduler - fair turns for everyone!"
 // Episode ref: "Takeaway" - managing everything at once, somehow
 // Bluey and all related characters are trademarks of Ludo Studio Pty Ltd,
@@ -17,30 +17,87 @@
 static process_t *run_queue   = NULL;   // circular linked list of runnable processes
 static process_t *sched_current = NULL;
 
+/* ---------------------------------------------------------------------------
+ * Completely Fair Scheduler (CFS)
+ *
+ * Each process has a vruntime that increments at a rate inversely proportional
+ * to its weight.  Priority 1..10 maps to weights derived from Linux's nice
+ * table centred on nice=0 (priority 5, weight 1024 = NICE_0_WEIGHT).
+ *
+ * vruntime_delta = delta_ticks * NICE_0_WEIGHT / task_weight
+ *
+ * The scheduler always picks the runnable process with the smallest vruntime.
+ * ---------------------------------------------------------------------------*/
+#define CFS_NICE0_WEIGHT  1024u
+
+/* Weights for priority 1..10 sampled from Linux's sched_prio_to_weight table
+ * (nice +4 down to nice -5). */
+static const uint32_t cfs_weight_table[10] = {
+    423u,   /* priority  1  (nice +4) */
+    526u,   /* priority  2  (nice +3) */
+    655u,   /* priority  3  (nice +2) */
+    820u,   /* priority  4  (nice +1) */
+    1024u,  /* priority  5  (nice  0) — baseline */
+    1277u,  /* priority  6  (nice -1) */
+    1586u,  /* priority  7  (nice -2) */
+    1991u,  /* priority  8  (nice -3) */
+    2501u,  /* priority  9  (nice -4) */
+    3121u,  /* priority 10  (nice -5) */
+};
+
+static uint32_t cfs_get_weight(const process_t *p) {
+    uint32_t pri = p->priority;
+    if (pri < 1u)  pri = 1u;
+    if (pri > 10u) pri = 10u;
+    return cfs_weight_table[pri - 1u];
+}
+
+/* Smallest vruntime among all runnable user processes (wrapping-safe). */
+static uint64_t cfs_min_vruntime(void) {
+    process_t *p = run_queue;
+    uint64_t min_vr = 0;
+    int first = 1;
+
+    if (!p) return 0;
+    do {
+        if ((p->flags & PROC_FLAG_USER_MODE) &&
+            (p->state == PROC_READY || p->state == PROC_RUNNING)) {
+            if (first || p->vruntime < min_vr) {
+                min_vr = p->vruntime;
+                first = 0;
+            }
+        }
+        p = p->sched_next;
+    } while (p && p != run_queue);
+
+    return min_vr;
+}
+
 static void scheduler_idle_fallback(void) {
     for (;;) __asm__ volatile("sti; hlt");
 }
 
+/* Pick the runnable user process with the smallest vruntime.
+ * When rotate=0 the current process is also a candidate (voluntary yield
+ * only switches if another process has strictly smaller vruntime). */
 static process_t *scheduler_pick_next_user(process_t *current, int rotate) {
-    process_t *start;
-    process_t *process;
+    process_t *p = run_queue;
+    process_t *best = NULL;
 
-    if (!run_queue) return NULL;
+    if (!p) return NULL;
 
-    if (current && current->sched_next) {
-        start = rotate ? current->sched_next : current;
-    } else {
-        start = run_queue;
-    }
-
-    process = start;
     do {
-        int runnable = (process->state == PROC_READY) || (!rotate && process == current && process->state == PROC_RUNNING);
-        if ((process->flags & PROC_FLAG_USER_MODE) && runnable) return process;
-        process = process->sched_next;
-    } while (process && process != start);
+        int runnable = (p->state == PROC_READY) ||
+                       (!rotate && p == current && p->state == PROC_RUNNING);
+        if ((p->flags & PROC_FLAG_USER_MODE) && runnable) {
+            if (!best || p->vruntime < best->vruntime) {
+                best = p;
+            }
+        }
+        p = p->sched_next;
+    } while (p && p != run_queue);
 
-    return NULL;
+    return best;
 }
 
 static void scheduler_prepare_fallback_frame(registers_t *regs) {
@@ -106,17 +163,26 @@ void scheduler_remove(uint32_t pid) {
     }
 }
 
-// Called from timer IRQ (IRQ0) every tick
-// Simple round-robin: advance to next READY process
+// Called from timer IRQ (IRQ0) every tick.
+// Wake sleeping processes; normalise vruntime of newly-woken processes so
+// they do not get a huge burst of CPU time after sleeping.
 void scheduler_tick(void) {
+    uint64_t min_vr;
+    process_t *p;
+
     if (!run_queue) return;
 
-    // Wake sleeping processes whose time has come
-    process_t *p = run_queue;
+    min_vr = cfs_min_vruntime();
+
+    p = run_queue;
     do {
         if (p->state == PROC_SLEEPING &&
             timer_get_ticks() >= p->sleep_until) {
             p->state = PROC_READY;
+            /* Clamp the waking process's vruntime to at least min_vruntime so
+             * it does not immediately starve everyone else. */
+            if (p->vruntime < min_vr)
+                p->vruntime = min_vr;
         }
         p = p->sched_next;
     } while (p != run_queue);
@@ -144,12 +210,19 @@ void scheduler_handle_trap(registers_t *regs, int rotate) {
     }
 
     if (current) {
-        /* Update CPU accounting for the outgoing process: accumulate ticks
-         * spent since it was scheduled in. */
+        /* Update CPU accounting and CFS vruntime for the outgoing process. */
         uint32_t now = timer_get_ticks();
         if (current->state == PROC_RUNNING) {
             if (now >= current->cpu_last_tick) {
-                current->cpu_ticks += (now - current->cpu_last_tick);
+                uint32_t delta = now - current->cpu_last_tick;
+                current->cpu_ticks += delta;
+                /* vruntime += delta * NICE_0_WEIGHT / task_weight
+                 * Compute in 32-bit to avoid __udivdi3 (unavailable in
+                 * freestanding kernel).  delta is small (1-20 ticks), so
+                 * delta * NICE_0_WEIGHT fits comfortably in uint32_t. */
+                uint32_t delta_vr = (delta * CFS_NICE0_WEIGHT) /
+                                    cfs_get_weight(current);
+                current->vruntime += (uint64_t)delta_vr;
             }
             current->state = PROC_READY;
         }

--- a/kernel/signal.c
+++ b/kernel/signal.c
@@ -264,14 +264,16 @@ int signal_sigaction(process_t *process, int sig,
 
     slot = &process->signal_actions[sig - 1];
     if (oldact) {
-        oldact->sa_handler = slot->handler;
-        oldact->sa_flags = slot->flags;
-        oldact->sa_mask = slot->mask;
+        oldact->sa_handler  = slot->handler;
+        oldact->sa_flags    = slot->flags;
+        oldact->sa_restorer = 0;   /* kernel owns the trampoline — no user restorer */
+        oldact->sa_mask     = slot->mask;
     }
     if (act) {
         slot->handler = act->sa_handler;
-        slot->flags = act->sa_flags;
-        slot->mask = act->sa_mask & ~(signal_bit(SIGKILL) | signal_bit(SIGSTOP));
+        slot->flags   = act->sa_flags;
+        /* sa_restorer is accepted but ignored: we always use our own trampoline. */
+        slot->mask    = act->sa_mask & ~(signal_bit(SIGKILL) | signal_bit(SIGSTOP));
     }
     return 0;
 }

--- a/kernel/signal.c
+++ b/kernel/signal.c
@@ -88,6 +88,13 @@ static void signal_ensure_trampoline(void) {
     paging_map(SIGNAL_TRAMPOLINE_ADDR, signal_trampoline_phys, PAGE_PRESENT | PAGE_USER);
 }
 
+void signal_map_trampoline_in_current_dir(void) {
+    /* Force a fresh map check against the currently-active page directory.
+     * Called after paging_switch_directory() in execve so the new address
+     * space always has the trampoline mapped at SIGNAL_TRAMPOLINE_ADDR. */
+    signal_ensure_trampoline();
+}
+
 static int signal_next_pending(process_t *process) {
     uint32_t pending;
 
@@ -202,6 +209,11 @@ int signal_dispatch_pending(process_t *process, registers_t *regs) {
     if (!process || !regs) return 0;
     if ((regs->cs & 0x3u) != 0x3u) return 0;
     if (process->flags & PROC_FLAG_SIGNAL_ACTIVE) return 0;
+
+    /* Vfork children share the parent's address space.  Writing a signal
+     * frame onto the stack would corrupt the parent's stack.  Leave all
+     * signals pending; they are delivered once exec() clears this flag. */
+    if (process->flags & PROC_FLAG_VFORK_SHARED_VM) return 0;
 
     sig = signal_next_pending(process);
     if (!sig) return 0;

--- a/kernel/signal.h
+++ b/kernel/signal.h
@@ -48,3 +48,7 @@ int         signal_sigprocmask(process_t *process, int how,
 							   uint32_t *oldset);
 int         signal_sigreturn(process_t *process, registers_t *regs, void *frame_ptr);
 void        signal_reset_on_exec(process_t *process);
+/* Map the signal trampoline into the currently-active page directory.
+ * Must be called after switching to a new address space (e.g. after execve)
+ * so that every process has the trampoline accessible at the well-known VA. */
+void        signal_map_trampoline_in_current_dir(void);

--- a/kernel/signal.h
+++ b/kernel/signal.h
@@ -15,7 +15,8 @@ typedef struct process process_t;
 typedef struct {
 	uint32_t sa_handler;
 	uint32_t sa_flags;
-	uint32_t sa_mask;
+	uint32_t sa_restorer;  /* Linux i386 ABI: restorer function pointer (offset +8) */
+	uint32_t sa_mask;      /* signal mask (offset +12, matching Linux i386 layout)   */
 } bluey_sigaction_t;
 
 #define SIGHUP    1

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -89,6 +89,7 @@ static int syscall_is_kernel_mode(const registers_t *regs) {
 }
 
 static int32_t sys_write(uint32_t fd, const char *buf, size_t len);
+static int32_t resolve_normalize_path(const char *path, char *out, size_t out_size);
 
 static int syscall_map_user_pages(process_t *process,
                                   uint32_t start,
@@ -749,7 +750,9 @@ static int32_t sys_statx(int dirfd, const char *path, int flags, uint32_t mask, 
         if ((flags & AT_SYMLINK_NOFOLLOW) != 0) {
             /* BlueyFS has no distinct lstat path yet; report regular metadata. */
         }
-        rc = vfs_stat(path, &st);
+        char _rpath[512];
+        if (resolve_normalize_path(path, _rpath, sizeof(_rpath)) != 0) return -BLUEY_EINVAL;
+        rc = vfs_stat(_rpath, &st);
         if (rc != 0) return -BLUEY_ENOENT;
     }
 
@@ -860,6 +863,9 @@ static void vfs_stat_to_buf(const vfs_stat_t *st, uint32_t *u) {
 static int32_t sys_stat(const char *path, void *buf) {
     if (!path) return -BLUEY_EFAULT;
     if (!buf)  return -BLUEY_EFAULT;
+    char _rpath[512];
+    if (resolve_normalize_path(path, _rpath, sizeof(_rpath)) != 0) return -BLUEY_EINVAL;
+    path = _rpath;
     vfs_stat_t st;
     if (vfs_stat(path, &st) != 0) return -BLUEY_ENOENT;
     vfs_stat_to_buf(&st, (uint32_t *)buf);
@@ -873,6 +879,9 @@ static int32_t sys_lstat(const char *path, void *buf) {
 
 static int32_t sys_access(const char *path, int mode) {
     if (!path) return -BLUEY_EFAULT;
+    char _rpath[512];
+    if (resolve_normalize_path(path, _rpath, sizeof(_rpath)) != 0) return -BLUEY_EINVAL;
+    path = _rpath;
     vfs_stat_t st;
     if (vfs_stat(path, &st) != 0) return -BLUEY_ENOENT;
     if (mode == 0) return 0; /* F_OK */
@@ -885,6 +894,9 @@ static int32_t sys_access(const char *path, int mode) {
 
 static int32_t sys_unlink(const char *path) {
     if (!path) return -BLUEY_EFAULT;
+    char _rpath[512];
+    if (resolve_normalize_path(path, _rpath, sizeof(_rpath)) != 0) return -BLUEY_EINVAL;
+    path = _rpath;
     /* First check whether the path exists so we can distinguish ENOENT
      * from other unlink failures (e.g., permissions or wrong type). */
     vfs_stat_t st;
@@ -899,12 +911,16 @@ static int32_t sys_unlink(const char *path) {
 static int32_t sys_mkdir(const char *path, uint32_t mode) {
     (void)mode;
     if (!path) return -BLUEY_EFAULT;
-    return vfs_mkdir(path);
+    char _rpath[512];
+    if (resolve_normalize_path(path, _rpath, sizeof(_rpath)) != 0) return -BLUEY_EINVAL;
+    return vfs_mkdir(_rpath);
 }
 
 static int32_t sys_rmdir(const char *path) {
     if (!path) return -BLUEY_EFAULT;
-    int32_t res = vfs_rmdir(path);
+    char _rpath[512];
+    if (resolve_normalize_path(path, _rpath, sizeof(_rpath)) != 0) return -BLUEY_EINVAL;
+    int32_t res = vfs_rmdir(_rpath);
     return res;
 }
 
@@ -1283,6 +1299,11 @@ static int32_t sys_rename(const char *oldpath, const char *newpath) {
     vfs_stat_t new_st;
 
     if (!oldpath || !newpath) return -BLUEY_EFAULT;
+    char _old[512], _new[512];
+    if (resolve_normalize_path(oldpath, _old, sizeof(_old)) != 0) return -BLUEY_EINVAL;
+    if (resolve_normalize_path(newpath, _new, sizeof(_new)) != 0) return -BLUEY_EINVAL;
+    oldpath = _old;
+    newpath = _new;
     if (strcmp(oldpath, newpath) == 0) return 0;
     if (vfs_stat(oldpath, &old_st) != 0) return -BLUEY_ENOENT;
     if (old_st.is_dir) return -BLUEY_EPERM;
@@ -1637,6 +1658,11 @@ static int32_t sys_prlimit64(uint32_t pid,
 }
 static int32_t sys_link(const char *oldpath, const char *newpath) {
     if (!oldpath || !newpath) return -BLUEY_EFAULT;
+    char _old[512], _new[512];
+    if (resolve_normalize_path(oldpath, _old, sizeof(_old)) != 0) return -BLUEY_EINVAL;
+    if (resolve_normalize_path(newpath, _new, sizeof(_new)) != 0) return -BLUEY_EINVAL;
+    oldpath = _old;
+    newpath = _new;
     vfs_stat_t st;
     if (vfs_stat(oldpath, &st) != 0) return -BLUEY_ENOENT;
     int r = vfs_link(oldpath, newpath);
@@ -1645,6 +1671,9 @@ static int32_t sys_link(const char *oldpath, const char *newpath) {
 
 static int32_t sys_symlink(const char *target, const char *linkpath) {
     if (!target || !linkpath) return -BLUEY_EFAULT;
+    char _lpath[512];
+    if (resolve_normalize_path(linkpath, _lpath, sizeof(_lpath)) != 0) return -BLUEY_EINVAL;
+    linkpath = _lpath;
     int r = vfs_symlink(target, linkpath);
     return (r == 0) ? 0 : -BLUEY_EPERM;
 }
@@ -1652,6 +1681,9 @@ static int32_t sys_symlink(const char *target, const char *linkpath) {
 static int32_t sys_readlink(const char *path, char *buf, uint32_t bufsize) {
     if (!path || !buf) return -BLUEY_EFAULT;
     if (bufsize == 0) return -BLUEY_EINVAL;
+    char _rpath[512];
+    if (resolve_normalize_path(path, _rpath, sizeof(_rpath)) != 0) return -BLUEY_EINVAL;
+    path = _rpath;
     vfs_stat_t st;
     if (vfs_stat(path, &st) != 0) return -BLUEY_ENOENT;
     /* readlink(2) requires the target to be a symlink */
@@ -1664,6 +1696,9 @@ static int32_t sys_readlink(const char *path, char *buf, uint32_t bufsize) {
 
 static int32_t sys_chmod(const char *path, uint32_t mode) {
     if (!path) return -BLUEY_EFAULT;
+    char _rpath[512];
+    if (resolve_normalize_path(path, _rpath, sizeof(_rpath)) != 0) return -BLUEY_EINVAL;
+    path = _rpath;
     vfs_stat_t st;
     if (vfs_stat(path, &st) != 0) return -BLUEY_ENOENT;
     int r = vfs_chmod(path, (uint16_t)mode);
@@ -1683,6 +1718,9 @@ static int32_t sys_fchmod(int fd, uint32_t mode) {
 
 static int32_t sys_chown(const char *path, uint32_t uid, uint32_t gid) {
     if (!path) return -BLUEY_EFAULT;
+    char _rpath[512];
+    if (resolve_normalize_path(path, _rpath, sizeof(_rpath)) != 0) return -BLUEY_EINVAL;
+    path = _rpath;
     vfs_stat_t st;
     if (vfs_stat(path, &st) != 0) return -BLUEY_ENOENT;
     int r = vfs_chown(path, uid, gid);
@@ -1691,6 +1729,9 @@ static int32_t sys_chown(const char *path, uint32_t uid, uint32_t gid) {
 
 static int32_t sys_lchown(const char *path, uint32_t uid, uint32_t gid) {
     if (!path) return -BLUEY_EFAULT;
+    char _rpath[512];
+    if (resolve_normalize_path(path, _rpath, sizeof(_rpath)) != 0) return -BLUEY_EINVAL;
+    path = _rpath;
     vfs_stat_t st;
     if (vfs_stat(path, &st) != 0) return -BLUEY_ENOENT;
     int r = vfs_lchown(path, uid, gid);
@@ -1814,6 +1855,9 @@ static int32_t sys_faccessat2(int dirfd, const char *path, int mode, int flags) 
         if (path[0] != '/') return -BLUEY_EBADF;
         /* absolute path: dirfd is irrelevant, proceed */
     }
+    char _rpath[512];
+    if (resolve_normalize_path(path, _rpath, sizeof(_rpath)) != 0) return -BLUEY_EINVAL;
+    path = _rpath;
     vfs_stat_t st;
     if (vfs_stat(path, &st) != 0) return -BLUEY_ENOENT;
     if (mode == 0) return 0; /* F_OK: existence only */
@@ -2272,6 +2316,10 @@ static int32_t sys_open(const char *path, int flags) {
 
     if (!path) return -BLUEY_EFAULT;
 
+    char _rpath[512];
+    if (resolve_normalize_path(path, _rpath, sizeof(_rpath)) != 0) return -BLUEY_EINVAL;
+    path = _rpath;
+
     access_mode = flags & 0x3;
     vfs_flags = access_mode | (flags & (VFS_O_CREAT | VFS_O_TRUNC | VFS_O_APPEND));
 
@@ -2326,6 +2374,21 @@ static int32_t sys_execve(registers_t *regs,
     if (!path_copy || !path_copy[0]) {
         result = path_copy ? -BLUEY_EINVAL : -BLUEY_E2BIG;
         goto cleanup;
+    }
+
+    /* Resolve relative path to absolute before any VFS operation. */
+    {
+        char _exec_rpath[512];
+        if (resolve_normalize_path(path_copy, _exec_rpath, sizeof(_exec_rpath)) != 0) {
+            result = -BLUEY_ENOENT;
+            goto cleanup;
+        }
+        size_t _rlen = strlen(_exec_rpath);
+        char *_resolved = (char*)kheap_alloc(_rlen + 1, 0);
+        if (!_resolved) { result = -BLUEY_ENOMEM; goto cleanup; }
+        memcpy(_resolved, _exec_rpath, _rlen + 1);
+        kheap_free(path_copy);
+        path_copy = _resolved;
     }
 
     argv_copy = syscall_copy_string_vector(argv, path_copy);

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -2023,6 +2023,14 @@ static int32_t sys_ioctl(int fd, uint32_t request, void *arg) {
     }
 }
 
+static int32_t sys_flock(int fd, int operation) {
+    (void)operation;
+
+    if (fd < 0) return -BLUEY_EBADF;
+    if ((fd <= 2) || vfs_fd_is_open(fd)) return 0;
+    return -BLUEY_EBADF;
+}
+
 /* ---- chdir / getcwd ----------------------------------------------------- */
 
 /* Resolve a user-supplied path against the current working directory and
@@ -3111,6 +3119,9 @@ int32_t syscall_dispatch(registers_t *regs) {
                              (void*)regs->edx,
                              (void*)regs->esi,
                              (const k_timeval_t*)regs->edi);
+            break;
+        case SYS_FLOCK:
+            ret = sys_flock((int)regs->ebx, (int)regs->ecx);
             break;
         case SYS_PSELECT6:
             ret = sys_pselect6((int)regs->ebx,

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -58,6 +58,7 @@ uint32_t syscall_saved_gs = 0;
 #define BLUEY_EPIPE  32
 #define BLUEY_EIO     5
 #define BLUEY_EMFILE 24
+#define BLUEY_ENFILE 23
 #define BLUEY_ENOTSOCK 88
 #define BLUEY_EADDRINUSE 98
 #define BLUEY_EAFNOSUPPORT 97
@@ -90,6 +91,12 @@ static int syscall_is_kernel_mode(const registers_t *regs) {
 
 static int32_t sys_write(uint32_t fd, const char *buf, size_t len);
 static int32_t resolve_normalize_path(const char *path, char *out, size_t out_size);
+
+static int32_t syscall_map_vfs_fd_error(int vfs_err) {
+    if (vfs_err == VFS_ERR_EMFILE) return -BLUEY_EMFILE;
+    if (vfs_err == VFS_ERR_ENFILE) return -BLUEY_ENFILE;
+    return -BLUEY_EBADF;
+}
 
 static int syscall_map_user_pages(process_t *process,
                                   uint32_t start,
@@ -352,7 +359,7 @@ static int32_t sys_setrlimit(uint32_t resource, uint32_t user_rlim_ptr) {
     uint32_t old_dir;
 
     if (!p) return -BLUEY_EPERM;
-    if (resource != RLIMIT_STACK) return -BLUEY_EINVAL;
+    if (resource != RLIMIT_STACK && resource != RLIMIT_NOFILE) return -BLUEY_EINVAL;
     if (!user_rlim_ptr) return -BLUEY_EFAULT;
 
     /* Copy from user memory */
@@ -366,8 +373,14 @@ static int32_t sys_setrlimit(uint32_t resource, uint32_t user_rlim_ptr) {
     /* Basic validation */
     if (rlim.rlim_cur > rlim.rlim_max) return -BLUEY_EINVAL;
 
-    p->rlimit_stack_cur = rlim.rlim_cur;
-    p->rlimit_stack_max = rlim.rlim_max;
+    if (resource == RLIMIT_STACK) {
+        p->rlimit_stack_cur = rlim.rlim_cur;
+        p->rlimit_stack_max = rlim.rlim_max;
+    } else {
+        if (rlim.rlim_cur < 3u) return -BLUEY_EINVAL;
+        p->rlimit_nofile_cur = rlim.rlim_cur;
+        p->rlimit_nofile_max = rlim.rlim_max;
+    }
     return 0;
 }
 
@@ -376,14 +389,19 @@ static int32_t sys_getrlimit(uint32_t resource, uint32_t user_rlim_ptr) {
     uint32_t old_dir;
 
     if (!p) return -BLUEY_EPERM;
-    if (resource != RLIMIT_STACK) return -BLUEY_EINVAL;
+    if (resource != RLIMIT_STACK && resource != RLIMIT_NOFILE) return -BLUEY_EINVAL;
     if (!user_rlim_ptr) return -BLUEY_EFAULT;
 
     old_dir = paging_current_directory();
     paging_switch_directory(p->page_dir);
     rlimit_t *u = (rlimit_t*)(uintptr_t)user_rlim_ptr;
-    u->rlim_cur = p->rlimit_stack_cur;
-    u->rlim_max = p->rlimit_stack_max;
+    if (resource == RLIMIT_STACK) {
+        u->rlim_cur = p->rlimit_stack_cur;
+        u->rlim_max = p->rlimit_stack_max;
+    } else {
+        u->rlim_cur = p->rlimit_nofile_cur;
+        u->rlim_max = p->rlimit_nofile_max;
+    }
     paging_switch_directory(old_dir);
     return 0;
 }
@@ -517,10 +535,39 @@ static int32_t sys_mprotect(registers_t *regs) {
     return 0;
 }
 
-static int32_t sys_rt_sigaction(int sig, const bluey_sigaction_t *act, bluey_sigaction_t *oldact) {
+static int32_t sys_rt_sigaction(int sig, const bluey_sigaction_t *act,
+                                bluey_sigaction_t *oldact, uint32_t sigsetsize) {
     process_t *process = process_current();
+    bluey_sigaction_t kact;
+    bluey_sigaction_t koldact;
+    int32_t result;
+
     if (!process) return -BLUEY_EPERM;
-    return signal_sigaction(process, sig, act, oldact);
+    /* Linux rt_sigaction requires sigsetsize == sizeof(kernel_sigset_t).
+     * We support 4-byte signal masks (signals 1-31). */
+    if (sigsetsize != sizeof(uint32_t)) return -BLUEY_EINVAL;
+
+    /* Copy act from user memory before calling signal_sigaction so that
+     * any corruption in user memory doesn't reach kernel internals via
+     * a live user pointer. */
+    if (act) {
+        uint32_t old_dir = paging_current_directory();
+        paging_switch_directory(process->page_dir);
+        kact = *act;
+        paging_switch_directory(old_dir);
+    }
+
+    result = signal_sigaction(process, sig, act ? &kact : NULL,
+                              oldact ? &koldact : NULL);
+    if (result != 0) return result;
+
+    if (oldact) {
+        uint32_t old_dir = paging_current_directory();
+        paging_switch_directory(process->page_dir);
+        *oldact = koldact;
+        paging_switch_directory(old_dir);
+    }
+    return 0;
 }
 
 static int32_t sys_rt_sigprocmask(int how, const uint32_t *set, uint32_t *oldset) {
@@ -1084,7 +1131,7 @@ static int32_t sys_socket_open(int domain, int type, int protocol) {
     fd = vfs_socket_open(socket_id);
     if (fd < 0) {
         socket_close(socket_id);
-        return -BLUEY_EMFILE;
+        return syscall_map_vfs_fd_error(vfs_get_last_error());
     }
 
     return fd;
@@ -1162,7 +1209,7 @@ static int32_t sys_socket_accept4(int fd, void *addr, uint32_t *addrlen, int fla
     newfd = vfs_socket_open(socket_id);
     if (newfd < 0) {
         socket_close(socket_id);
-        return -BLUEY_EMFILE;
+        return syscall_map_vfs_fd_error(vfs_get_last_error());
     }
     return newfd;
 }
@@ -1354,7 +1401,7 @@ static int32_t sys_select(int nfds,
             else if (vfs_fd_is_devev(fd)) is_ready = devev_pending();
             else if (vfs_fd_is_tty(fd)) is_ready = 1;
             else if (vfs_fd_is_socket(fd)) is_ready = socket_is_readable(vfs_socket_id(fd));
-            else if (fd >= 3 && fd < VFS_MAX_OPEN) is_ready = 1;
+            else if (fd >= 3 && vfs_fd_is_open(fd)) is_ready = 1;
 
             if (is_ready) {
                 ready_read[word] |= mask;
@@ -1367,7 +1414,7 @@ static int32_t sys_select(int nfds,
             if (fd == 1 || fd == 2) is_ready = 1;
             else if (vfs_fd_is_tty(fd)) is_ready = 1;
             else if (vfs_fd_is_socket(fd)) is_ready = socket_is_writable(vfs_socket_id(fd));
-            else if (fd >= 3 && fd < VFS_MAX_OPEN) is_ready = 1;
+            else if (fd >= 3 && vfs_fd_is_open(fd)) is_ready = 1;
 
             if (is_ready) {
                 ready_write[word] |= mask;
@@ -1606,7 +1653,7 @@ static int32_t sys_prlimit64(uint32_t pid,
     uint32_t old_dir;
 
     if (!caller) return -BLUEY_EPERM;
-    if (resource != RLIMIT_STACK) return -BLUEY_EINVAL;
+    if (resource != RLIMIT_STACK && resource != RLIMIT_NOFILE) return -BLUEY_EINVAL;
 
     if (pid == 0 || pid == caller->pid) {
         target = caller;
@@ -1636,17 +1683,30 @@ static int32_t sys_prlimit64(uint32_t pid,
         else if (requested.rlim_max <= 0xFFFFFFFFull) new_max = (uint32_t)requested.rlim_max;
         else return -BLUEY_EINVAL;
 
-        target->rlimit_stack_cur = new_cur;
-        target->rlimit_stack_max = new_max;
+        if (resource == RLIMIT_STACK) {
+            target->rlimit_stack_cur = new_cur;
+            target->rlimit_stack_max = new_max;
+        } else {
+            if (new_cur < 3u) return -BLUEY_EINVAL;
+            target->rlimit_nofile_cur = new_cur;
+            target->rlimit_nofile_max = new_max;
+        }
     }
 
     if (old_limit_ptr) {
         compat_rlimit64_t current;
 
-        current.rlim_cur = (target->rlimit_stack_cur == 0xFFFFFFFFu)
-            ? ~0ull : (uint64_t)target->rlimit_stack_cur;
-        current.rlim_max = (target->rlimit_stack_max == 0xFFFFFFFFu)
-            ? ~0ull : (uint64_t)target->rlimit_stack_max;
+        if (resource == RLIMIT_STACK) {
+            current.rlim_cur = (target->rlimit_stack_cur == 0xFFFFFFFFu)
+                ? ~0ull : (uint64_t)target->rlimit_stack_cur;
+            current.rlim_max = (target->rlimit_stack_max == 0xFFFFFFFFu)
+                ? ~0ull : (uint64_t)target->rlimit_stack_max;
+        } else {
+            current.rlim_cur = (target->rlimit_nofile_cur == 0xFFFFFFFFu)
+                ? ~0ull : (uint64_t)target->rlimit_nofile_cur;
+            current.rlim_max = (target->rlimit_nofile_max == 0xFFFFFFFFu)
+                ? ~0ull : (uint64_t)target->rlimit_nofile_max;
+        }
 
         old_dir = paging_current_directory();
         paging_switch_directory(caller->page_dir);
@@ -1809,19 +1869,19 @@ static int32_t sys__llseek(uint32_t fd, uint32_t offset_hi, uint32_t offset_lo,
 static int32_t sys_dup(int oldfd) {
     if (oldfd < 0) return -BLUEY_EBADF;
     int r = vfs_dup(oldfd);
-    return r < 0 ? -BLUEY_EBADF : r;
+    return r < 0 ? syscall_map_vfs_fd_error(vfs_get_last_error()) : r;
 }
 
 static int32_t sys_dup2_impl(int oldfd, int newfd) {
     if (oldfd < 0 || newfd < 0) return -BLUEY_EBADF;
     int r = vfs_dup2(oldfd, newfd);
-    return r < 0 ? -BLUEY_EBADF : r;
+    return r < 0 ? syscall_map_vfs_fd_error(vfs_get_last_error()) : r;
 }
 
 static int32_t sys_pipe_impl(int *fds) {
     if (!fds) return -BLUEY_EFAULT;
     int r = vfs_pipe(fds);
-    return r < 0 ? r : 0;
+    return r < 0 ? syscall_map_vfs_fd_error(vfs_get_last_error()) : 0;
 }
 
 /* pipe2(fds, flags) — identical to pipe() for our purposes.
@@ -1835,7 +1895,7 @@ static int32_t sys_pipe2(int *fds, int flags) {
 #undef PIPE2_VALID_FLAGS
     if (!fds) return -BLUEY_EFAULT;
     int r = vfs_pipe(fds);
-    return r < 0 ? r : 0;
+    return r < 0 ? syscall_map_vfs_fd_error(vfs_get_last_error()) : 0;
 }
 
 /* faccessat2(dirfd, path, mode, flags) — check file accessibility.
@@ -1884,10 +1944,8 @@ static int32_t sys_fcntl(int fd, int cmd, int arg) {
             int r = vfs_dup_above(fd, arg);
             if (r < 0) {
                 /* Preserve EBADF for invalid input fds; map other failures to EMFILE */
-                if (r == -BLUEY_EBADF) {
-                    return r;
-                }
-                return -BLUEY_EMFILE;
+                if (vfs_get_last_error() == VFS_ERR_EBADF) return -BLUEY_EBADF;
+                return syscall_map_vfs_fd_error(vfs_get_last_error());
             }
             return r;
         }
@@ -2120,6 +2178,18 @@ typedef struct {
     char     d_name[1]; /* variable length */
 } k_dirent_t;
 
+typedef struct {
+    uint64_t d_ino;
+    uint64_t d_off;
+    uint16_t d_reclen;
+    uint8_t  d_type;
+    char     d_name[1]; /* variable length */
+} k_dirent64_t;
+
+#define K_DT_UNKNOWN 0
+#define K_DT_DIR     4
+#define K_DT_REG     8
+
 static int32_t sys_getdents(int fd, void *buf, uint32_t count) {
     if (!buf) return -BLUEY_EFAULT;
     if (fd < 0) return -BLUEY_EBADF;
@@ -2153,6 +2223,44 @@ static int32_t sys_getdents(int fd, void *buf, uint32_t count) {
         memcpy(de->d_name, entries[i].name, namelen + 1);
 
         out     += reclen;
+        written += reclen;
+    }
+
+    return (int32_t)written;
+}
+
+static int32_t sys_getdents64(int fd, void *buf, uint32_t count) {
+    if (!buf) return -BLUEY_EFAULT;
+    if (fd < 0) return -BLUEY_EBADF;
+
+    vfs_stat_t fst;
+    if (vfs_fstat(fd, &fst) != 0) return -BLUEY_EBADF;
+    if (!fst.is_dir) return -BLUEY_ENOTDIR;
+
+    const char *fdpath = vfs_fd_get_path(fd);
+    const char *dirpath = fdpath ? fdpath : process_get_cwd();
+    vfs_dirent_t entries[32];
+    int nent = vfs_readdir(dirpath, entries, 32);
+    if (nent < 0) return -BLUEY_EINVAL;
+
+    uint8_t *out = (uint8_t *)buf;
+    uint32_t written = 0;
+
+    for (int i = 0; i < nent; i++) {
+        size_t namelen = strlen(entries[i].name);
+        uint16_t reclen = (uint16_t)((sizeof(uint64_t) + sizeof(uint64_t) +
+                                      sizeof(uint16_t) + sizeof(uint8_t) +
+                                      namelen + 1 + 7) & ~7u);
+        if (written + reclen > count) break;
+
+        k_dirent64_t *de = (k_dirent64_t *)out;
+        de->d_ino = entries[i].inode ? (uint64_t)entries[i].inode : (uint64_t)(i + 1);
+        de->d_off = (uint64_t)(written + reclen);
+        de->d_reclen = reclen;
+        de->d_type = entries[i].is_dir ? K_DT_DIR : K_DT_REG;
+        memcpy(de->d_name, entries[i].name, namelen + 1);
+
+        out += reclen;
         written += reclen;
     }
 
@@ -2293,7 +2401,7 @@ static int32_t sys_write(uint32_t fd, const char *buf, size_t len) {
         tty_flush();
         return (int32_t)len;
     }
-    if (fd < VFS_MAX_OPEN && vfs_fd_is_tty((int)fd)) {
+    if (vfs_fd_is_tty((int)fd)) {
         if (!buf) return -BLUEY_EFAULT;
         if (len == 0) return 0;
         if (len > 4096) len = 4096;
@@ -2329,6 +2437,10 @@ static int32_t sys_open(const char *path, int flags) {
 
     fd = vfs_open(path, vfs_flags);
     if (fd >= 0) return fd;
+
+    if (vfs_get_last_error() == VFS_ERR_EMFILE || vfs_get_last_error() == VFS_ERR_ENFILE) {
+        return syscall_map_vfs_fd_error(vfs_get_last_error());
+    }
 
     if (vfs_stat(path, &stat) != 0) return -BLUEY_ENOENT;
     if (stat.is_dir) return -BLUEY_EISDIR;
@@ -2469,7 +2581,7 @@ static int32_t sys_read(uint32_t fd, char *buf, size_t len) {
         if (len == 0) return 0;
         return tty_read(buf, len);
     }
-    if (fd < VFS_MAX_OPEN && vfs_fd_is_tty((int)fd)) {
+    if (vfs_fd_is_tty((int)fd)) {
         if (!buf) return -BLUEY_EFAULT;
         if (len == 0) return 0;
         return vfs_read((int)fd, (uint8_t *)buf, len);
@@ -2515,6 +2627,16 @@ static int32_t sys_gethostname(char *buf, size_t len) {
 
 static int32_t sys_setpgid(uint32_t pid, uint32_t pgid) {
     return process_setpgid(pid, pgid);
+}
+
+static int32_t sys_setsid(void) {
+    process_t *p = process_current();
+
+    if (!p) return -BLUEY_EPERM;
+    if (p->pgid == p->pid) return -BLUEY_EPERM;
+
+    p->pgid = p->pid;
+    return (int32_t)p->pid;
 }
 
 static int32_t sys_getpgid(uint32_t pid) {
@@ -2742,6 +2864,9 @@ int32_t syscall_dispatch(registers_t *regs) {
         case SYS_GETDENTS:
             ret = sys_getdents((int)regs->ebx, (void*)regs->ecx, regs->edx);
             break;
+        case SYS_GETDENTS64:
+            ret = sys_getdents64((int)regs->ebx, (void*)regs->ecx, regs->edx);
+            break;
         case SYS_KILL:
             ret = sys_kill((int32_t)regs->ebx, (int)regs->ecx);
             break;
@@ -2848,7 +2973,8 @@ int32_t syscall_dispatch(registers_t *regs) {
         case SYS_RT_SIGACTION:
             ret = sys_rt_sigaction((int)regs->ebx,
                                    (const bluey_sigaction_t*)regs->ecx,
-                                   (bluey_sigaction_t*)regs->edx);
+                                   (bluey_sigaction_t*)regs->edx,
+                                   (uint32_t)regs->esi);
             break;
         case SYS_RT_SIGPROCMASK:
             ret = sys_rt_sigprocmask((int)regs->ebx,
@@ -2908,6 +3034,9 @@ int32_t syscall_dispatch(registers_t *regs) {
             break;
         case SYS_GETPGRP:
             ret = sys_getpgrp();
+            break;
+        case SYS_SETSID:
+            ret = sys_setsid();
             break;
         /* ---- Mount / umount -------------------------------------------- */
         case SYS_MOUNT:

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -2428,6 +2428,8 @@ static int32_t sys_execve(registers_t *regs,
                          image.stack_base, image.stack_top, image.page_dir);
     process_set_memory_layout(process, image.image_end);
     paging_switch_directory(image.page_dir);
+    /* Ensure the signal trampoline is mapped in the new address space. */
+    signal_map_trampoline_in_current_dir();
     process_set_current(process);
     syscall_prepare_user_return(regs, process);
     if (stat.mode & VFS_S_ISUID || stat.mode & VFS_S_ISGID) {

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -2202,28 +2202,47 @@ static int32_t sys_getdents(int fd, void *buf, uint32_t count) {
     /* Use the path stored for the fd if available; fall back to cwd */
     const char *fdpath = vfs_fd_get_path(fd);
     const char *dirpath = fdpath ? fdpath : process_get_cwd();
+    int32_t cur_off = vfs_lseek(fd, 0, VFS_SEEK_CUR);
+    if (cur_off < 0) return -BLUEY_EBADF;
+
     vfs_dirent_t entries[32];
     int nent = vfs_readdir(dirpath, entries, 32);
     if (nent < 0) return -BLUEY_EINVAL;
 
     uint8_t *out = (uint8_t *)buf;
     uint32_t written = 0;
+    uint32_t stream_off = 0;
 
     for (int i = 0; i < nent; i++) {
         size_t namelen = strlen(entries[i].name);
         /* dirent record: d_ino(4) + d_off(4) + d_reclen(2) + name + NUL, aligned to 4 */
         uint16_t reclen = (uint16_t)((sizeof(uint32_t) + sizeof(uint32_t) +
                                       sizeof(uint16_t) + namelen + 1 + 3) & ~3u);
-        if (written + reclen > count) break;
+        if (stream_off + reclen <= (uint32_t)cur_off) {
+            stream_off += reclen;
+            continue;
+        }
+
+        if (written + reclen > count) {
+            if (written == 0) return -BLUEY_EINVAL;
+            break;
+        }
 
         k_dirent_t *de = (k_dirent_t *)out;
         de->d_ino    = entries[i].inode ? entries[i].inode : (uint32_t)(i + 1);
-        de->d_off    = written + reclen;
+        de->d_off    = stream_off + reclen;
         de->d_reclen = reclen;
         memcpy(de->d_name, entries[i].name, namelen + 1);
 
         out     += reclen;
         written += reclen;
+        stream_off += reclen;
+    }
+
+    if (written > 0) {
+        (void)vfs_lseek(fd, cur_off + (int32_t)written, VFS_SEEK_SET);
+    } else {
+        (void)vfs_lseek(fd, (int32_t)stream_off, VFS_SEEK_SET);
     }
 
     return (int32_t)written;
@@ -2239,29 +2258,48 @@ static int32_t sys_getdents64(int fd, void *buf, uint32_t count) {
 
     const char *fdpath = vfs_fd_get_path(fd);
     const char *dirpath = fdpath ? fdpath : process_get_cwd();
+    int32_t cur_off = vfs_lseek(fd, 0, VFS_SEEK_CUR);
+    if (cur_off < 0) return -BLUEY_EBADF;
+
     vfs_dirent_t entries[32];
     int nent = vfs_readdir(dirpath, entries, 32);
     if (nent < 0) return -BLUEY_EINVAL;
 
     uint8_t *out = (uint8_t *)buf;
     uint32_t written = 0;
+    uint32_t stream_off = 0;
 
     for (int i = 0; i < nent; i++) {
         size_t namelen = strlen(entries[i].name);
         uint16_t reclen = (uint16_t)((sizeof(uint64_t) + sizeof(uint64_t) +
                                       sizeof(uint16_t) + sizeof(uint8_t) +
                                       namelen + 1 + 7) & ~7u);
-        if (written + reclen > count) break;
+        if (stream_off + reclen <= (uint32_t)cur_off) {
+            stream_off += reclen;
+            continue;
+        }
+
+        if (written + reclen > count) {
+            if (written == 0) return -BLUEY_EINVAL;
+            break;
+        }
 
         k_dirent64_t *de = (k_dirent64_t *)out;
         de->d_ino = entries[i].inode ? (uint64_t)entries[i].inode : (uint64_t)(i + 1);
-        de->d_off = (uint64_t)(written + reclen);
+        de->d_off = (uint64_t)(stream_off + reclen);
         de->d_reclen = reclen;
         de->d_type = entries[i].is_dir ? K_DT_DIR : K_DT_REG;
         memcpy(de->d_name, entries[i].name, namelen + 1);
 
         out += reclen;
         written += reclen;
+        stream_off += reclen;
+    }
+
+    if (written > 0) {
+        (void)vfs_lseek(fd, cur_off + (int32_t)written, VFS_SEEK_SET);
+    } else {
+        (void)vfs_lseek(fd, (int32_t)stream_off, VFS_SEEK_SET);
     }
 
     return (int32_t)written;
@@ -2370,6 +2408,15 @@ void syscall_init(void) {
 
 // SYS_WRITE (1): fd=1/2 -> stdout/stderr -> TTY; fd>=3 -> VFS
 static int32_t sys_write(uint32_t fd, const char *buf, size_t len) {
+    /* If userspace remapped this descriptor via dup/dup2/fcntl(F_DUPFD),
+     * honor the VFS binding first (including fd 0/1/2). */
+    if (vfs_fd_is_open((int)fd)) {
+        if (!buf) return -BLUEY_EFAULT;
+        if (len == 0) return 0;
+        if (len > 4096) len = 4096;
+        return vfs_write((int)fd, (const uint8_t *)buf, len);
+    }
+
     if (fd == 1 || fd == 2) {
         if (!buf) return -BLUEY_EFAULT;
         if (len == 0) return 0;
@@ -2576,6 +2623,14 @@ cleanup:
 
 // SYS_READ (0): fd=0 -> stdin -> TTY; fd>=3 -> VFS
 static int32_t sys_read(uint32_t fd, char *buf, size_t len) {
+    /* If userspace remapped this descriptor via dup/dup2/fcntl(F_DUPFD),
+     * honor the VFS binding first (including fd 0/1/2). */
+    if (vfs_fd_is_open((int)fd)) {
+        if (!buf) return -BLUEY_EFAULT;
+        if (len == 0) return 0;
+        return vfs_read((int)fd, (uint8_t *)buf, len);
+    }
+
     if (fd == 0) {
         if (!buf) return -BLUEY_EFAULT;
         if (len == 0) return 0;

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -24,6 +24,7 @@
 #define SYS_LCHOWN        16  /* lchown (16-bit uid/gid variant) */
 #define SYS_LSEEK         19
 #define SYS_SELECT        142
+#define SYS_FLOCK         143
 #define SYS_GETPID        20
 #define SYS_MOUNT         21
 #define SYS_GETUID        24

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -59,6 +59,7 @@
 #define SYS_SETRLIMIT     75
 #define SYS_GETRLIMIT     76
 #define SYS_GETDENTS      141
+#define SYS_GETDENTS64    220
 #define SYS_MKDIR         39
 #define SYS_RMDIR         40
 #define SYS_DUP           41
@@ -74,6 +75,7 @@
 #define SYS_FCNTL64       221
 #define SYS_GETPPID       64
 #define SYS_WAIT4         114
+#define SYS_SETSID        66
 #define SYS_SCHED_YIELD   158
 #define SYS_NANOSLEEP     162
 #define SYS_CHOWN         182

--- a/kernel/syslog.c
+++ b/kernel/syslog.c
@@ -15,6 +15,7 @@
 #include "../drivers/vga.h"
 #include "../fs/vfs.h"
 #include "syslog.h"
+#include "rtc.h"
 #include <stdarg.h>
 #include "kheap.h"
 
@@ -149,6 +150,19 @@ void syslog_init(void) {
     syslog_ready     = 1;
 }
 
+static int syslog_snprintf(char *out, size_t sz, const char *fmt, ...);
+
+/* Return the basename portion of a file path (the part after the last '/'). */
+static const char *syslog_basename(const char *path) {
+    const char *last = path;
+    if (!path) return "";
+    while (*path) {
+        if (*path == '/') last = path + 1;
+        path++;
+    }
+    return last;
+}
+
 static int syslog_snprintf(char *out, size_t sz, const char *fmt, ...) {
     va_list ap;
     va_start(ap, fmt);
@@ -185,23 +199,37 @@ static int verbose_console_threshold(void) {
     }
 }
 
-void syslog_write(int level, const char *tag, const char *fmt, ...) {
+static void syslog_write_loc_va(int level, const char *tag, const char *file,
+                                const char *func, const char *fmt, va_list ap) {
     if (!syslog_ready) return;
 
     syslog_entry_t *entry = &syslog_ring[syslog_head % SYSLOG_RING_ENTRIES];
 
-    entry->seq   = syslog_seq++;
-    entry->level = (uint8_t)level;
+    entry->seq       = syslog_seq++;
+    entry->timestamp = rtc_get_uptime_seconds();
+    entry->level     = (uint8_t)level;
 
     // Copy tag (truncate to 15 chars)
     strncpy(entry->tag, tag ? tag : "KERN", sizeof(entry->tag) - 1);
     entry->tag[sizeof(entry->tag) - 1] = '\0';
 
+    // Store source location (basename only to save space)
+    if (file && file[0]) {
+        const char *base = syslog_basename(file);
+        strncpy(entry->src_file, base, sizeof(entry->src_file) - 1);
+        entry->src_file[sizeof(entry->src_file) - 1] = '\0';
+    } else {
+        entry->src_file[0] = '\0';
+    }
+    if (func && func[0]) {
+        strncpy(entry->src_func, func, sizeof(entry->src_func) - 1);
+        entry->src_func[sizeof(entry->src_func) - 1] = '\0';
+    } else {
+        entry->src_func[0] = '\0';
+    }
+
     // Format message
-    va_list ap;
-    va_start(ap, fmt);
     syslog_vsnprintf(entry->msg, sizeof(entry->msg), fmt, ap);
-    va_end(ap);
 
     syslog_head++;
     if (syslog_count_val < SYSLOG_RING_ENTRIES) syslog_count_val++;
@@ -212,9 +240,30 @@ void syslog_write(int level, const char *tag, const char *fmt, ...) {
         else if (level == LOG_WARNING)  vga_set_color(VGA_LIGHT_BROWN, VGA_BLACK);
         else if (level == LOG_DEBUG)    vga_set_color(VGA_DARK_GREY,   VGA_BLACK);
         else                            vga_set_color(VGA_WHITE,       VGA_BLACK);
-        kprintf("[%s] %s\n", entry->tag, entry->msg);
+        if (g_verbose_level >= VERBOSE_INFO && entry->src_file[0] != '\0') {
+            kprintf("[%4u][%s](%s:%s) %s\n",
+                    entry->timestamp, entry->tag,
+                    entry->src_file, entry->src_func, entry->msg);
+        } else {
+            kprintf("[%4u][%s] %s\n", entry->timestamp, entry->tag, entry->msg);
+        }
         vga_set_color(VGA_WHITE, VGA_BLACK);
     }
+}
+
+void syslog_write(int level, const char *tag, const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    syslog_write_loc_va(level, tag, NULL, NULL, fmt, ap);
+    va_end(ap);
+}
+
+void syslog_write_loc(int level, const char *tag, const char *file,
+                      const char *func, const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    syslog_write_loc_va(level, tag, file, func, fmt, ap);
+    va_end(ap);
 }
 
 uint32_t syslog_count(void) {
@@ -256,8 +305,11 @@ void syslog_dmesg(void) {
         else if (e->level == LOG_DEBUG)   vga_set_color(VGA_DARK_GREY,   VGA_BLACK);
         else                              vga_set_color(VGA_WHITE,       VGA_BLACK);
 
-        kprintf("[%u] %s [%s] %s\n",
-                e->seq, level_str((int)e->level), e->tag, e->msg);
+        kprintf("[%u] [T+%us] %s [%s] %s\n",
+                e->seq, e->timestamp, level_str((int)e->level), e->tag, e->msg);
+        if (g_verbose_level >= VERBOSE_INFO && e->src_file[0] != '\0') {
+            kprintf("         src: %s:%s\n", e->src_file, e->src_func);
+        }
     }
     vga_set_color(VGA_WHITE, VGA_BLACK);
     kprintf("-- end of kernel log --\n");
@@ -360,17 +412,22 @@ void syslog_flush_to_fs(void) {
         }
 
         /* Now write out the snapshot without holding locks or disabling IRQs. */
-        char line[SYSLOG_MSG_MAX + 64];
+        char line[SYSLOG_MSG_MAX + 160];
         for (uint32_t i = 0; i < n; i++) {
             syslog_entry_t *e = &snapshot[i];
             char lvlbuf[16];
             strncpy(lvlbuf, level_str((int)e->level), sizeof(lvlbuf) - 1);
             lvlbuf[sizeof(lvlbuf) - 1] = '\0';
 
-            int len = syslog_snprintf(line, sizeof(line), "[%u] %s [%s] %s\n",
-                                      e->seq, lvlbuf, e->tag, e->msg);
-
-            /* Handle partial writes */
+            int len;
+            if (e->src_file[0] != '\0') {
+                len = syslog_snprintf(line, sizeof(line), "[%u] [T+%us] %s [%s](%s:%s) %s\n",
+                                      e->seq, e->timestamp, lvlbuf, e->tag,
+                                      e->src_file, e->src_func, e->msg);
+            } else {
+                len = syslog_snprintf(line, sizeof(line), "[%u] [T+%us] %s [%s] %s\n",
+                                      e->seq, e->timestamp, lvlbuf, e->tag, e->msg);
+            }
             size_t written = 0;
             while (written < (size_t)len) {
                 int r = vfs_write(fd, (const uint8_t *)line + written, (size_t)len - written);
@@ -382,15 +439,22 @@ void syslog_flush_to_fs(void) {
         kheap_free(snapshot);
     } else {
         /* Allocation failed: fall back to direct writes but be defensive. */
-        char line[SYSLOG_MSG_MAX + 64];
+        char line[SYSLOG_MSG_MAX + 160];
         for (uint32_t i = 0; i < n; i++) {
             syslog_entry_t *e = &syslog_ring[(start + i) % SYSLOG_RING_ENTRIES];
             char lvlbuf[16];
             strncpy(lvlbuf, level_str((int)e->level), sizeof(lvlbuf) - 1);
             lvlbuf[sizeof(lvlbuf) - 1] = '\0';
 
-            int len = syslog_snprintf(line, sizeof(line), "[%u] %s [%s] %s\n",
-                                      e->seq, lvlbuf, e->tag, e->msg);
+            int len;
+            if (e->src_file[0] != '\0') {
+                len = syslog_snprintf(line, sizeof(line), "[%u] [T+%us] %s [%s](%s:%s) %s\n",
+                                      e->seq, e->timestamp, lvlbuf, e->tag,
+                                      e->src_file, e->src_func, e->msg);
+            } else {
+                len = syslog_snprintf(line, sizeof(line), "[%u] [T+%us] %s [%s] %s\n",
+                                      e->seq, e->timestamp, lvlbuf, e->tag, e->msg);
+            }
 
             size_t written = 0;
             while (written < (size_t)len) {

--- a/kernel/syslog.h
+++ b/kernel/syslog.h
@@ -37,10 +37,13 @@
 // Log entry (stored in the ring buffer as a packed record)
 // ---------------------------------------------------------------------------
 typedef struct {
-    uint32_t seq;       /* monotonically increasing sequence number */
-    uint8_t  level;     /* LOG_* severity */
-    uint8_t  _pad[3];   /* padding for alignment */
-    char     tag[16];   /* subsystem tag, e.g. "KERN", "NET", "FS" */
+    uint32_t seq;             /* monotonically increasing sequence number */
+    uint32_t timestamp;       /* kernel uptime in seconds at time of write */
+    uint8_t  level;           /* LOG_* severity */
+    uint8_t  _pad[3];         /* padding for alignment */
+    char     tag[16];         /* subsystem tag, e.g. "KERN", "NET", "FS" */
+    char     src_file[32];    /* source basename (from __FILE__), via syslog_write_loc */
+    char     src_func[32];    /* source function name (from __func__), via syslog_write_loc */
     char     msg[SYSLOG_MSG_MAX];
 } syslog_entry_t;
 
@@ -54,15 +57,24 @@ void syslog_init(void);
 // Write a log entry.  level = LOG_*  tag = short subsystem name.
 void syslog_write(int level, const char *tag, const char *fmt, ...);
 
+// Write a log entry with source-location context (file and function name).
+// Prefer using the syslog_* macros below, which supply __FILE__/__func__
+// automatically.  Call this directly only when source location is known at
+// the call site but cannot be captured by a macro.
+void syslog_write_loc(int level, const char *tag, const char *file,
+                      const char *func, const char *fmt, ...);
+
 // Convenience macros — mirrors the Linux pr_* family.
-#define syslog_emerg(tag, ...)   syslog_write(LOG_EMERG,   tag, __VA_ARGS__)
-#define syslog_alert(tag, ...)   syslog_write(LOG_ALERT,   tag, __VA_ARGS__)
-#define syslog_crit(tag, ...)    syslog_write(LOG_CRIT,    tag, __VA_ARGS__)
-#define syslog_err(tag, ...)     syslog_write(LOG_ERR,     tag, __VA_ARGS__)
-#define syslog_warn(tag, ...)    syslog_write(LOG_WARNING, tag, __VA_ARGS__)
-#define syslog_notice(tag, ...)  syslog_write(LOG_NOTICE,  tag, __VA_ARGS__)
-#define syslog_info(tag, ...)    syslog_write(LOG_INFO,    tag, __VA_ARGS__)
-#define syslog_debug(tag, ...)   syslog_write(LOG_DEBUG,   tag, __VA_ARGS__)
+// These capture __FILE__ and __func__ so verbose output can show the
+// originating source module.
+#define syslog_emerg(tag, ...)   syslog_write_loc(LOG_EMERG,   tag, __FILE__, __func__, __VA_ARGS__)
+#define syslog_alert(tag, ...)   syslog_write_loc(LOG_ALERT,   tag, __FILE__, __func__, __VA_ARGS__)
+#define syslog_crit(tag, ...)    syslog_write_loc(LOG_CRIT,    tag, __FILE__, __func__, __VA_ARGS__)
+#define syslog_err(tag, ...)     syslog_write_loc(LOG_ERR,     tag, __FILE__, __func__, __VA_ARGS__)
+#define syslog_warn(tag, ...)    syslog_write_loc(LOG_WARNING, tag, __FILE__, __func__, __VA_ARGS__)
+#define syslog_notice(tag, ...)  syslog_write_loc(LOG_NOTICE,  tag, __FILE__, __func__, __VA_ARGS__)
+#define syslog_info(tag, ...)    syslog_write_loc(LOG_INFO,    tag, __FILE__, __func__, __VA_ARGS__)
+#define syslog_debug(tag, ...)   syslog_write_loc(LOG_DEBUG,   tag, __FILE__, __func__, __VA_ARGS__)
 
 // Flush the in-RAM ring buffer to /var/log/kernel.log on the mounted VFS.
 // Call this after vfs_mount() succeeds.  Safe to call multiple times.

--- a/kernel/tty.c
+++ b/kernel/tty.c
@@ -131,11 +131,17 @@ void tty_write(const char *buf, size_t len) {
 
 char tty_getchar(void) {
     char ch;
+    uint32_t flags;
 
     while (!tty_input_available()) {
         tty_poll_input_sources();
         if (tty_input_available()) break;
-        __asm__ volatile("sti; hlt; cli");
+        __asm__ volatile("pushf; pop %0" : "=r"(flags) : : "memory");
+        if ((flags & 0x200u) != 0u) {
+            __asm__ volatile("sti; hlt" : : : "memory");
+        } else {
+            __asm__ volatile("sti; hlt; cli" : : : "memory");
+        }
     }
 
     tty_poll_input_sources();

--- a/kernel/tty.c
+++ b/kernel/tty.c
@@ -8,6 +8,7 @@
 #include "process.h"
 #include "signal.h"
 #include "tty.h"
+#include "../lib/string.h"
 
 static int tty_ready = 0;
 #define TTY_SERIAL_PORT 0x3F8
@@ -70,6 +71,16 @@ static void tty_serial_putchar(char c) {
     outb(TTY_SERIAL_PORT, (uint8_t)c);
 }
 
+static int tty_serial_input_available(void) {
+    return (inb(TTY_SERIAL_PORT + 5) & 0x01u) != 0;
+}
+
+static void tty_poll_input_sources(void) {
+    while (tty_serial_input_available()) {
+        tty_input_char((char)inb(TTY_SERIAL_PORT));
+    }
+}
+
 static void tty_output_char(char c) {
     outb(0xE9, (uint8_t)c);
     tty_serial_putchar(c);
@@ -122,9 +133,12 @@ char tty_getchar(void) {
     char ch;
 
     while (!tty_input_available()) {
-        __asm__ volatile("hlt");
+        tty_poll_input_sources();
+        if (tty_input_available()) break;
+        __asm__ volatile("sti; hlt; cli");
     }
 
+    tty_poll_input_sources();
     ch = (char)tty_input_pop();
     return ch;
 }

--- a/kernel/tty.c
+++ b/kernel/tty.c
@@ -21,6 +21,7 @@ static int tty_ready = 0;
 #define TTY_LFLAG_ISIG   0x00000001u
 #define TTY_LFLAG_ICANON 0x00000002u
 #define TTY_LFLAG_ECHO   0x00000008u
+#define TTY_EFLAGS_IF    0x00000200u
 
 typedef struct {
     char input_buf[TTY_INPUT_BUF_SIZE];
@@ -137,7 +138,7 @@ char tty_getchar(void) {
         tty_poll_input_sources();
         if (tty_input_available()) break;
         __asm__ volatile("pushf; pop %0" : "=r"(flags) : : "memory");
-        if ((flags & 0x200u) != 0u) {
+        if ((flags & TTY_EFLAGS_IF) != 0u) {
             __asm__ volatile("sti; hlt" : : : "memory");
         } else {
             __asm__ volatile("sti; hlt; cli" : : : "memory");

--- a/tools/init-installer.sh
+++ b/tools/init-installer.sh
@@ -12,8 +12,8 @@ if [ -f /installed ]; then
 fi
 
 mkdir -p /mnt/boot
-# Try common device names for the boot partition
-mount /dev/hda1 /mnt/boot 2>/dev/null || mount /dev/sda1 /mnt/boot 2>/dev/null || true
+# Try common device names for the boot partition (BSD-style preferred, Linux aliases as fallback)
+mount /dev/disk0s1 /mnt/boot 2>/dev/null || mount /dev/disk1s1 /mnt/boot 2>/dev/null || mount /dev/hda1 /mnt/boot 2>/dev/null || mount /dev/sda1 /mnt/boot 2>/dev/null || true
 
 if [ -d /mnt/boot/stage ]; then
   echo "Installing stage from /mnt/boot/stage..."

--- a/tools/mkbluey_disk.py
+++ b/tools/mkbluey_disk.py
@@ -13,6 +13,29 @@ FS_BLOCK_SIZE = 4096
 BOOT_START_LBA = 2048
 BOOT_MB = 32
 DEFAULT_ROOT_BUFFER_PCT = 30
+
+DEFAULT_PASSWD = """root:x:0:0:root:/root:/bin/sh
+bandit:x:0:0:Bandit Heeler (Root):/root:/bin/sh
+bluey:x:1:1:Bluey Heeler:/home/bluey:/bin/sh
+bingo:x:2:1:Bingo Heeler:/home/bingo:/bin/sh
+chilli:x:3:1:Chilli Heeler:/home/chilli:/bin/sh
+jack:x:4:2:Jack (Bluey's mate):/home/jack:/bin/sh
+judo:x:5:2:Judo:/home/judo:/bin/sh
+"""
+
+DEFAULT_GROUP = """root:x:0:root,bandit
+heelers:x:1:bluey,bingo,chilli,bandit
+mates:x:2:jack,judo
+"""
+
+DEFAULT_SHADOW = """root:$6$blueyos$i71qzV0KYDjxto0fG97RZJk/yuMr.qZzc9zx79xmx9pm56pa5v6liPjsPiSa61tRrhF0j/cLIqXhrHd.GWm7K0:0:0:99999:7:::
+bandit:$6$blueyos$i71qzV0KYDjxto0fG97RZJk/yuMr.qZzc9zx79xmx9pm56pa5v6liPjsPiSa61tRrhF0j/cLIqXhrHd.GWm7K0:0:0:99999:7:::
+bluey:$pbkdf2-sha256$10000$7d9f4a1e0c0b5f6e1122334455667788$f5f07c6926875023aedfd2087b52e1dca0c596b16e7d3a360ac744eec25720f5:0:0:99999:7:::
+bingo:!:0:0:99999:7:::
+chilli:*:0:0:99999:7:::
+jack:*:0:0:99999:7:::
+judo:*:0:0:99999:7:::
+"""
 MBR_PARTITION_TABLE_OFFSET = 446
 MBR_ENTRY_SIZE = 16
 BLUEYFS_INODE_SIZE = 256
@@ -67,22 +90,50 @@ def estimate_directory_payload(root_dir: Path) -> tuple[int, int, int, int, int]
     total_dirs = 0
     total_files = 0
     total_indirect_blocks = 0
-    visited_dirs: set[Path] = set()
+    active_real_dirs: set[Path] = set()
+    root_dir_resolved = root_dir.resolve()
+
+    def resolve_packaged_path(entry: Path) -> Path | None:
+        if not entry.is_symlink():
+            return entry
+
+        link_target = os.readlink(entry)
+        if os.path.isabs(link_target):
+            candidate = root_dir_resolved / link_target.lstrip("/")
+        else:
+            candidate = entry.parent / link_target
+
+        resolved = candidate.resolve()
+        try:
+            resolved.relative_to(root_dir_resolved)
+        except ValueError:
+            return None
+        return resolved
 
     def scan_dir(path: Path) -> None:
         nonlocal total_file_bytes, total_file_blocks, total_dirs, total_files, total_indirect_blocks
         real_path = path.resolve()
-        if real_path in visited_dirs:
+        if real_path in active_real_dirs:
             return
-        visited_dirs.add(real_path)
+        active_real_dirs.add(real_path)
 
-        for entry in path.iterdir():
+        try:
+            entries = list(path.iterdir())
+        except OSError:
+            active_real_dirs.remove(real_path)
+            return
+
+        for entry in entries:
             try:
-                if entry.is_dir():
+                packaged_path = resolve_packaged_path(entry)
+                if packaged_path is None:
+                    continue
+
+                if packaged_path.is_dir():
                     total_dirs += 1
-                    scan_dir(entry)
-                elif entry.is_file():
-                    size_bytes = entry.stat().st_size
+                    scan_dir(packaged_path)
+                elif packaged_path.is_file():
+                    size_bytes = packaged_path.stat().st_size
                     file_blocks = blocks_from_bytes(size_bytes)
                     total_files += 1
                     total_file_bytes += size_bytes
@@ -90,6 +141,8 @@ def estimate_directory_payload(root_dir: Path) -> tuple[int, int, int, int, int]
                     total_indirect_blocks += pointer_metadata_blocks(file_blocks)
             except OSError:
                 continue
+
+        active_real_dirs.remove(real_path)
 
     scan_dir(root_dir)
     return total_file_bytes, total_file_blocks, total_dirs, total_files, total_indirect_blocks
@@ -208,7 +261,7 @@ def write_partition_region(image: Path, offset_lba: int, partition_image: Path) 
         shutil.copyfileobj(part_fp, disk_fp)
 
 
-def build_boot_partition(repo: Path, image: Path, kernel_path: Path, boot_sectors: int, root_device: str, root_fstype: str, boot_extra_dir: str = None, init_kernel_path: str = "/sbin/claw") -> None:
+def build_boot_partition(repo: Path, image: Path, kernel_path: Path, boot_sectors: int, root_device: str, root_fstype: str, boot_extra_dir: str | None = None, init_kernel_path: str = "/sbin/claw") -> None:
     boot_size_bytes = boot_sectors * SECTOR_SIZE
     boot_img = image.with_suffix(".boot.tmp")
     boot_stage = image.parent / ".boot-stage"
@@ -380,13 +433,101 @@ def read_existing_layout(image: Path) -> tuple[int, int, int, int, int, int]:
     return boot_start, boot_sectors, root_start, root_sectors, swap_start, swap_sectors
 
 
-def prepare_root_extra_dir(root_extra_dir: str | None, timezone_file: str | None) -> str | None:
+def stage_root_extra_dir(root_extra: Path) -> Path:
+    stage_dir = Path(tempfile.mkdtemp(prefix="blueyos-root-extra."))
+    shutil.copytree(root_extra, stage_dir, symlinks=True, dirs_exist_ok=True)
+    print(f"[DISK] Staged root-extra-dir in {stage_dir}")
+    return stage_dir
+
+
+def ensure_default_account_files(root_extra: Path) -> None:
+    etc_dir = root_extra / "etc"
+    etc_dir.mkdir(parents=True, exist_ok=True)
+
+    account_files = (
+        (etc_dir / "passwd", DEFAULT_PASSWD, 0o644),
+        (etc_dir / "group", DEFAULT_GROUP, 0o644),
+        (etc_dir / "shadow", DEFAULT_SHADOW, 0o600),
+    )
+
+    for path, content, mode in account_files:
+        if path.exists():
+            continue
+        path.write_text(content, encoding="ascii")
+        path.chmod(mode)
+        print(f"[DISK] Provisioned missing {path.relative_to(root_extra)}")
+
+
+def maybe_override_login_binary(repo: Path, root_extra: Path) -> None:
+    local_login = repo.parent.parent / "login-tools" / "pkg" / "payload" / "usr" / "bin" / "login"
+    target_login = root_extra / "usr" / "bin" / "login"
+
+    if not local_login.exists():
+        return
+
+    target_login.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(local_login, target_login)
+    print(f"[DISK] Using locally built login binary from {local_login}")
+
+
+def limit_claw_login_services(root_extra: Path) -> None:
+    manifest_path = root_extra / "etc" / "claw" / "units.manifest"
+    target_path = root_extra / "etc" / "claw" / "targets.d" / "claw-multiuser.target.yml"
+    basic_target_path = root_extra / "etc" / "claw" / "targets.d" / "claw-basic.target.yml"
+
+    if manifest_path.exists():
+        manifest_lines = [line.strip() for line in manifest_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        filtered_lines = []
+        for line in manifest_lines:
+            if line.endswith("matey@tty2.yml") or line.endswith("matey@tty3.yml"):
+                continue
+            filtered_lines.append(line)
+        if filtered_lines != manifest_lines:
+            manifest_path.write_text("\n".join(filtered_lines) + "\n", encoding="utf-8")
+            print("[DISK] Limited claw manifest to matey@tty1 for login validation")
+
+    if target_path.exists():
+        target_text = target_path.read_text(encoding="utf-8")
+        updated_text = target_text.replace("wants: matey@tty1 matey@tty2 matey@tty3", "wants: matey@tty1")
+        if not basic_target_path.exists():
+            updated_text = updated_text.replace("requires: claw-basic.target\n", "")
+            updated_text = updated_text.replace("after: claw-basic.target\n", "")
+        if updated_text != target_text:
+            target_path.write_text(updated_text, encoding="utf-8")
+            print("[DISK] Limited claw-multiuser.target to matey@tty1")
+
+    if not basic_target_path.exists():
+        for service_name in ("matey@tty1.yml", "matey@tty2.yml", "matey@tty3.yml"):
+            service_path = root_extra / "etc" / "claw" / "services.d" / service_name
+            if not service_path.exists():
+                continue
+            service_text = service_path.read_text(encoding="utf-8")
+            updated_text = service_text.replace("after: claw-basic.target\n", "")
+            if updated_text != service_text:
+                service_path.write_text(updated_text, encoding="utf-8")
+                print(f"[DISK] Removed missing claw-basic.target dependency from {service_name}")
+
+
+def prepare_root_extra_dir(repo: Path, root_extra_dir: str | None, timezone_file: str | None) -> tuple[str | None, str | None]:
     if not root_extra_dir:
-        return None
+        return None, None
 
     root_extra = Path(root_extra_dir)
     if not root_extra.exists() or not root_extra.is_dir():
         raise SystemExit(f"--root-extra-dir not found or not a dir: {root_extra_dir}")
+
+    effective_root = root_extra
+    cleanup_dir: Path | None = None
+
+    login_compat_path = root_extra / "sbin" / "login"
+    usr_bin_login = root_extra / "usr" / "bin" / "login"
+    if not login_compat_path.exists() and usr_bin_login.exists():
+        effective_root = stage_root_extra_dir(root_extra)
+        cleanup_dir = effective_root
+
+    ensure_default_account_files(effective_root)
+    maybe_override_login_binary(repo, effective_root)
+    limit_claw_login_services(effective_root)
 
     # Seed the runtime tree claw expects even when the external sysroot was
     # installed without empty directories.
@@ -401,21 +542,31 @@ def prepare_root_extra_dir(root_extra_dir: str | None, timezone_file: str | None
         "var/log",
         "var/log/claw",
     ):
-        (root_extra / relpath).mkdir(parents=True, exist_ok=True)
+        (effective_root / relpath).mkdir(parents=True, exist_ok=True)
 
-    localtime_path = root_extra / "etc" / "localtime"
+    login_compat_path = effective_root / "sbin" / "login"
+    usr_bin_login = effective_root / "usr" / "bin" / "login"
+    if not login_compat_path.exists() and usr_bin_login.exists():
+        login_compat_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            login_compat_path.symlink_to(Path("..") / "usr" / "bin" / "login")
+            print("[DISK] Provisioned /sbin/login -> ../usr/bin/login compatibility link")
+        except FileExistsError:
+            pass
+
+    localtime_path = effective_root / "etc" / "localtime"
     if localtime_path.exists() or not timezone_file:
-        return str(root_extra)
+        return str(effective_root), str(cleanup_dir) if cleanup_dir else None
 
     tz_source = Path(timezone_file)
     if not tz_source.exists() or not tz_source.is_file():
         print(f"[DISK] Timezone source missing, skipping /etc/localtime provisioning: {tz_source}")
-        return str(root_extra)
+        return str(effective_root), str(cleanup_dir) if cleanup_dir else None
 
     localtime_path.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(tz_source, localtime_path)
     print(f"[DISK] Provisioned /etc/localtime from {tz_source}")
-    return str(root_extra)
+    return str(effective_root), str(cleanup_dir) if cleanup_dir else None
 
 
 def main() -> int:
@@ -465,7 +616,8 @@ def main() -> int:
             print(f"[DISK] Using /bin/init from root-extra-dir: {init_path}")
     mkfs_tool = repo / args.mkfs_tool
     mkswap_tool = repo / args.mkswap_tool
-    effective_root_extra_dir = prepare_root_extra_dir(
+    effective_root_extra_dir, cleanup_root_extra_dir = prepare_root_extra_dir(
+        repo,
         getattr(args, 'root_extra_dir', None),
         getattr(args, 'timezone_file', None),
     )
@@ -487,30 +639,23 @@ def main() -> int:
     if not mkswap_tool.exists():
         raise SystemExit(f"missing mkswap tool: {mkswap_tool}")
 
+    requested_root_sectors, requested_root_size_details = estimate_root_partition_sectors(
+        effective_root_extra_dir,
+        init_path,
+        fstab_path,
+        args.root_mb,
+        args.root_buffer_pct,
+    )
+
     recreate_image = args.erase or not image.exists()
-    root_size_details = {"dynamic": False, "payload_bytes": 0, "total_mb": args.root_mb}
+    root_size_details = requested_root_size_details
+    boot_sectors = 0
+    root_start = 0
+    root_sectors = 0
+    swap_start = 0
+    swap_sectors = 0
 
-    if recreate_image:
-        boot_sectors = sectors_from_mb(args.boot_mb)
-        swap_sectors = sectors_from_mb(args.swap_mb)
-        slack_sectors = sectors_from_mb(args.slack_mb)
-        root_sectors, root_size_details = estimate_root_partition_sectors(
-            effective_root_extra_dir,
-            init_path,
-            fstab_path,
-            args.root_mb,
-            args.root_buffer_pct,
-        )
-        root_start = BOOT_START_LBA + boot_sectors
-        swap_start = root_start + root_sectors
-        total_sectors = swap_start + swap_sectors + slack_sectors
-        total_bytes = total_sectors * SECTOR_SIZE
-
-        with image.open("wb") as fp:
-            fp.truncate(total_bytes)
-
-        write_mbr(image, BOOT_START_LBA, boot_sectors, root_start, root_sectors, swap_start, swap_sectors)
-    else:
+    if not recreate_image:
         _boot_start, boot_sectors, root_start, root_sectors, swap_start, swap_sectors = read_existing_layout(image)
         required_bytes = (swap_start + swap_sectors) * SECTOR_SIZE
         image_bytes = image.stat().st_size
@@ -518,7 +663,29 @@ def main() -> int:
             raise SystemExit(
                 f"existing image is smaller than its partition table expects ({image_bytes} < {required_bytes}); use --erase"
             )
-        print(f"[DISK] Reusing existing image layout in {image}")
+        if root_sectors < requested_root_sectors:
+            print(
+                "[DISK] Existing root partition too small for current payload: "
+                f"{root_sectors * SECTOR_SIZE // (1024 * 1024)} MiB < "
+                f"{requested_root_sectors * SECTOR_SIZE // (1024 * 1024)} MiB; recreating image"
+            )
+            recreate_image = True
+        else:
+            print(f"[DISK] Reusing existing image layout in {image}")
+
+    if recreate_image:
+        boot_sectors = sectors_from_mb(args.boot_mb)
+        swap_sectors = sectors_from_mb(args.swap_mb)
+        slack_sectors = sectors_from_mb(args.slack_mb)
+        root_sectors = requested_root_sectors
+        root_start = BOOT_START_LBA + boot_sectors
+        swap_start = root_start + root_sectors
+        total_sectors = swap_start + swap_sectors + slack_sectors
+        total_bytes = total_sectors * SECTOR_SIZE
+
+        with image.open("wb") as fp:
+            fp.truncate(total_bytes)
+        write_mbr(image, BOOT_START_LBA, boot_sectors, root_start, root_sectors, swap_start, swap_sectors)
 
     try:
         if root_size_details["dynamic"]:
@@ -551,6 +718,8 @@ def main() -> int:
             os.unlink(fstab_name)
         except OSError:
             pass
+        if cleanup_root_extra_dir:
+            shutil.rmtree(cleanup_root_extra_dir, ignore_errors=True)
 
     print(f"[DISK] Built {image.name} with ext2 boot at LBA {BOOT_START_LBA}, BlueyFS root at LBA {root_start}, and swap at LBA {swap_start}")
     print("[DISK] Installed GRUB boot.img in the MBR and embedded core.img in the post-MBR gap.")

--- a/tools/mkbluey_disk.py
+++ b/tools/mkbluey_disk.py
@@ -13,6 +13,8 @@ FS_BLOCK_SIZE = 4096
 BOOT_START_LBA = 2048
 BOOT_MB = 32
 DEFAULT_ROOT_BUFFER_PCT = 30
+MBR_PARTITION_TABLE_OFFSET = 446
+MBR_ENTRY_SIZE = 16
 BLUEYFS_INODE_SIZE = 256
 BLUEYFS_INODES_PER_GROUP = 8192
 BLUEYFS_BLOCKS_PER_GROUP = 8192
@@ -206,8 +208,7 @@ def write_partition_region(image: Path, offset_lba: int, partition_image: Path) 
         shutil.copyfileobj(part_fp, disk_fp)
 
 
-def build_boot_partition(repo: Path, image: Path, kernel_path: Path, boot_mb: int, root_device: str, root_fstype: str, boot_extra_dir: str = None, init_kernel_path: str = "/sbin/claw") -> None:
-    boot_sectors = sectors_from_mb(boot_mb)
+def build_boot_partition(repo: Path, image: Path, kernel_path: Path, boot_sectors: int, root_device: str, root_fstype: str, boot_extra_dir: str = None, init_kernel_path: str = "/sbin/claw") -> None:
     boot_size_bytes = boot_sectors * SECTOR_SIZE
     boot_img = image.with_suffix(".boot.tmp")
     boot_stage = image.parent / ".boot-stage"
@@ -354,6 +355,31 @@ def run(cmd, cwd: Path) -> None:
     subprocess.run(cmd, cwd=str(cwd), check=True)
 
 
+def read_existing_layout(image: Path) -> tuple[int, int, int, int, int, int]:
+    with image.open("rb") as fp:
+        mbr = fp.read(SECTOR_SIZE)
+
+    if len(mbr) != SECTOR_SIZE or mbr[510:512] != b"\x55\xaa":
+        raise SystemExit(f"invalid or missing MBR in existing image: {image}")
+
+    def read_entry(index: int) -> tuple[int, int]:
+        offset = MBR_PARTITION_TABLE_OFFSET + index * MBR_ENTRY_SIZE
+        _status, _chs_first, _ptype, _chs_last, start_lba, sectors = struct.unpack_from("<B3sB3sII", mbr, offset)
+        if start_lba == 0 or sectors == 0:
+            raise SystemExit(f"missing partition entry {index + 1} in existing image: {image}")
+        return start_lba, sectors
+
+    boot_start, boot_sectors = read_entry(0)
+    root_start, root_sectors = read_entry(1)
+    swap_start, swap_sectors = read_entry(2)
+    if boot_start != BOOT_START_LBA:
+        raise SystemExit(
+            f"unexpected boot partition start in existing image ({boot_start}); expected {BOOT_START_LBA}. Use --erase to rebuild."
+        )
+
+    return boot_start, boot_sectors, root_start, root_sectors, swap_start, swap_sectors
+
+
 def prepare_root_extra_dir(root_extra_dir: str | None, timezone_file: str | None) -> str | None:
     if not root_extra_dir:
         return None
@@ -415,6 +441,8 @@ def main() -> int:
                         help="Kernel commandline init= path to embed in grub.cfg (default: /sbin/claw)")
     parser.add_argument("--timezone-file", default="/usr/share/zoneinfo/Australia/Brisbane",
                         help="Host tzfile to install as /etc/localtime when root-extra-dir lacks one")
+    parser.add_argument("--erase", action="store_true",
+                        help="Wipe and recreate the full disk layout before populating partitions")
     args = parser.parse_args()
 
     repo = Path(__file__).resolve().parent.parent
@@ -441,26 +469,12 @@ def main() -> int:
         getattr(args, 'root_extra_dir', None),
         getattr(args, 'timezone_file', None),
     )
-    boot_sectors = sectors_from_mb(args.boot_mb)
-    swap_sectors = sectors_from_mb(args.swap_mb)
-    slack_sectors = sectors_from_mb(args.slack_mb)
     with tempfile.NamedTemporaryFile("w", delete=False, encoding="ascii", newline="\n") as fstab_fp:
         fstab_fp.write("# BlueyOS mount table - Chilli keeps it organised\n")
         fstab_fp.write("/dev/disk0s2 / blueyfs defaults 0 1\n")
         fstab_fp.write("/dev/disk0s3 none swap defaults 0 0\n")
         fstab_name = fstab_fp.name
     fstab_path = Path(fstab_name)
-    root_sectors, root_size_details = estimate_root_partition_sectors(
-        effective_root_extra_dir,
-        init_path,
-        fstab_path,
-        args.root_mb,
-        args.root_buffer_pct,
-    )
-    root_start = BOOT_START_LBA + boot_sectors
-    swap_start = root_start + root_sectors
-    total_sectors = swap_start + swap_sectors + slack_sectors
-    total_bytes = total_sectors * SECTOR_SIZE
 
     image.parent.mkdir(parents=True, exist_ok=True)
 
@@ -473,10 +487,38 @@ def main() -> int:
     if not mkswap_tool.exists():
         raise SystemExit(f"missing mkswap tool: {mkswap_tool}")
 
-    with image.open("wb") as fp:
-        fp.truncate(total_bytes)
+    recreate_image = args.erase or not image.exists()
+    root_size_details = {"dynamic": False, "payload_bytes": 0, "total_mb": args.root_mb}
 
-    write_mbr(image, BOOT_START_LBA, boot_sectors, root_start, root_sectors, swap_start, swap_sectors)
+    if recreate_image:
+        boot_sectors = sectors_from_mb(args.boot_mb)
+        swap_sectors = sectors_from_mb(args.swap_mb)
+        slack_sectors = sectors_from_mb(args.slack_mb)
+        root_sectors, root_size_details = estimate_root_partition_sectors(
+            effective_root_extra_dir,
+            init_path,
+            fstab_path,
+            args.root_mb,
+            args.root_buffer_pct,
+        )
+        root_start = BOOT_START_LBA + boot_sectors
+        swap_start = root_start + root_sectors
+        total_sectors = swap_start + swap_sectors + slack_sectors
+        total_bytes = total_sectors * SECTOR_SIZE
+
+        with image.open("wb") as fp:
+            fp.truncate(total_bytes)
+
+        write_mbr(image, BOOT_START_LBA, boot_sectors, root_start, root_sectors, swap_start, swap_sectors)
+    else:
+        _boot_start, boot_sectors, root_start, root_sectors, swap_start, swap_sectors = read_existing_layout(image)
+        required_bytes = (swap_start + swap_sectors) * SECTOR_SIZE
+        image_bytes = image.stat().st_size
+        if image_bytes < required_bytes:
+            raise SystemExit(
+                f"existing image is smaller than its partition table expects ({image_bytes} < {required_bytes}); use --erase"
+            )
+        print(f"[DISK] Reusing existing image layout in {image}")
 
     try:
         if root_size_details["dynamic"]:
@@ -489,7 +531,7 @@ def main() -> int:
         else:
             print(f"[DISK] Root partition using fallback size: {args.root_mb} MiB")
 
-        build_boot_partition(repo, image, kernel_path, args.boot_mb, "/dev/disk0s2", "blueyfs", getattr(args, 'boot_extra_dir', None), getattr(args, 'init_kernel_path', '/sbin/claw'))
+        build_boot_partition(repo, image, kernel_path, boot_sectors, "/dev/disk0s2", "blueyfs", getattr(args, 'boot_extra_dir', None), getattr(args, 'init_kernel_path', '/sbin/claw'))
 
         mkfs_cmd = [str(mkfs_tool), "-F", "-L", args.root_label, "-o", str(root_start), "-n", str(root_sectors), "-I", str(init_path), "-T", fstab_name]
         if effective_root_extra_dir:

--- a/tools/mkbluey_disk.py
+++ b/tools/mkbluey_disk.py
@@ -446,8 +446,8 @@ def main() -> int:
     slack_sectors = sectors_from_mb(args.slack_mb)
     with tempfile.NamedTemporaryFile("w", delete=False, encoding="ascii", newline="\n") as fstab_fp:
         fstab_fp.write("# BlueyOS mount table - Chilli keeps it organised\n")
-        fstab_fp.write("/dev/hda2 / blueyfs defaults 0 1\n")
-        fstab_fp.write("/dev/hda3 none swap defaults 0 0\n")
+        fstab_fp.write("/dev/disk0s2 / blueyfs defaults 0 1\n")
+        fstab_fp.write("/dev/disk0s3 none swap defaults 0 0\n")
         fstab_name = fstab_fp.name
     fstab_path = Path(fstab_name)
     root_sectors, root_size_details = estimate_root_partition_sectors(
@@ -489,7 +489,7 @@ def main() -> int:
         else:
             print(f"[DISK] Root partition using fallback size: {args.root_mb} MiB")
 
-        build_boot_partition(repo, image, kernel_path, args.boot_mb, "/dev/hda2", "blueyfs", getattr(args, 'boot_extra_dir', None), getattr(args, 'init_kernel_path', '/sbin/claw'))
+        build_boot_partition(repo, image, kernel_path, args.boot_mb, "/dev/disk0s2", "blueyfs", getattr(args, 'boot_extra_dir', None), getattr(args, 'init_kernel_path', '/sbin/claw'))
 
         mkfs_cmd = [str(mkfs_tool), "-F", "-L", args.root_label, "-o", str(root_start), "-n", str(root_sectors), "-I", str(init_path), "-T", fstab_name]
         if effective_root_extra_dir:

--- a/tools/mkbluey_disk.py
+++ b/tools/mkbluey_disk.py
@@ -28,8 +28,8 @@ heelers:x:1:bluey,bingo,chilli,bandit
 mates:x:2:jack,judo
 """
 
-DEFAULT_SHADOW = """root:$6$blueyos$i71qzV0KYDjxto0fG97RZJk/yuMr.qZzc9zx79xmx9pm56pa5v6liPjsPiSa61tRrhF0j/cLIqXhrHd.GWm7K0:0:0:99999:7:::
-bandit:$6$blueyos$i71qzV0KYDjxto0fG97RZJk/yuMr.qZzc9zx79xmx9pm56pa5v6liPjsPiSa61tRrhF0j/cLIqXhrHd.GWm7K0:0:0:99999:7:::
+DEFAULT_SHADOW = """root:!:0:0:99999:7:::
+bandit:!:0:0:99999:7:::
 bluey:$pbkdf2-sha256$10000$7d9f4a1e0c0b5f6e1122334455667788$f5f07c6926875023aedfd2087b52e1dca0c596b16e7d3a360ac744eec25720f5:0:0:99999:7:::
 bingo:!:0:0:99999:7:::
 chilli:*:0:0:99999:7:::

--- a/tools/mkfs_blueyfs.c
+++ b/tools/mkfs_blueyfs.c
@@ -853,7 +853,8 @@ static uint32_t dir_lookup_host(uint32_t dir_ino, const char *name) {
     return 0;
 }
 
-static int create_dir_host(uint32_t parent_ino, const char *name, uint32_t now, uint32_t *ino_out) {
+static int create_dir_host(uint32_t parent_ino, const char *name, uint32_t now, uint32_t *ino_out,
+                           mode_t host_mode, uint32_t host_uid, uint32_t host_gid) {
     uint32_t ino = alloc_inode_host();
     uint32_t data_blk = alloc_block_host();
     biscuitfs_inode_t inode;
@@ -865,9 +866,9 @@ static int create_dir_host(uint32_t parent_ino, const char *name, uint32_t now, 
     if (!ino || !data_blk) return -1;
 
     memset(&inode, 0, sizeof(inode));
-    inode.mode = BISCUITFS_IFDIR | 0755;
-    inode.uid = 0;
-    inode.gid = 0;
+    inode.mode = (uint16_t)(BISCUITFS_IFDIR | (host_mode & 07777));
+    inode.uid = (uint16_t)host_uid;
+    inode.gid = (uint16_t)host_gid;
     inode.links_count = 2;
     inode.atime = now;
     inode.ctime = now;
@@ -909,7 +910,8 @@ static int create_dir_host(uint32_t parent_ino, const char *name, uint32_t now, 
 }
 
 static int create_file_host(uint32_t parent_ino, const char *name,
-                            const uint8_t *data, size_t len, uint32_t now) {
+                            const uint8_t *data, size_t len, uint32_t now,
+                            mode_t host_mode, uint32_t host_uid, uint32_t host_gid) {
     uint32_t ino = alloc_inode_host();
     biscuitfs_inode_t inode;
     size_t remaining = len;
@@ -919,9 +921,9 @@ static int create_file_host(uint32_t parent_ino, const char *name,
     if (!ino) return -1;
 
     memset(&inode, 0, sizeof(inode));
-    inode.mode = BISCUITFS_IFREG | 0755;
-    inode.uid = 0;
-    inode.gid = 0;
+    inode.mode = (uint16_t)(BISCUITFS_IFREG | (host_mode & 07777));
+    inode.uid = (uint16_t)host_uid;
+    inode.gid = (uint16_t)host_gid;
     inode.links_count = 1;
     inode.atime = now;
     inode.ctime = now;
@@ -1006,12 +1008,12 @@ static int populate_standard_layout(const char *init_path, const char *fstab_pat
     load_superblock(&sb);
     now = sb.wtime;
 
-    if (create_dir_host(BISCUITFS_ROOT_INO, "bin", now, &bin_ino) != 0) return -1;
-    if (create_dir_host(BISCUITFS_ROOT_INO, "etc", now, &etc_ino) != 0) return -1;
+    if (create_dir_host(BISCUITFS_ROOT_INO, "bin", now, &bin_ino, 0755, 0, 0) != 0) return -1;
+    if (create_dir_host(BISCUITFS_ROOT_INO, "etc", now, &etc_ino, 0755, 0, 0) != 0) return -1;
 
     if (init_path) {
         if (read_host_file(init_path, &data, &size) != 0) return -1;
-        if (create_file_host(bin_ino, "init", data, size, now) != 0) {
+        if (create_file_host(bin_ino, "init", data, size, now, 0755, 0, 0) != 0) {
             free(data);
             return -1;
         }
@@ -1021,7 +1023,7 @@ static int populate_standard_layout(const char *init_path, const char *fstab_pat
 
     if (fstab_path) {
         if (read_host_file(fstab_path, &data, &size) != 0) return -1;
-        if (create_file_host(etc_ino, "fstab", data, size, now) != 0) {
+        if (create_file_host(etc_ino, "fstab", data, size, now, 0644, 0, 0) != 0) {
             free(data);
             return -1;
         }
@@ -1112,10 +1114,20 @@ static int populate_from_dir_recursive(uint32_t parent_ino, const char *src_base
             /* Reuse existing directory if present */
             child_ino = dir_lookup_host(parent_ino, de->d_name);
             if (!child_ino) {
-                if (create_dir_host(parent_ino, de->d_name, now, &child_ino) != 0) {
+                if (create_dir_host(parent_ino, de->d_name, now, &child_ino,
+                                    st.st_mode, (uint32_t)st.st_uid, (uint32_t)st.st_gid) != 0) {
                     fprintf(stderr, "mkfs: create_dir_host failed for '%s' under parent ino %u\n", relchild, parent_ino);
                     closedir(d);
                     return -1;
+                }
+            } else {
+                /* Directory already exists — update its mode/ownership to match host. */
+                biscuitfs_inode_t existing;
+                if (read_inode_host(child_ino, &existing) == 0) {
+                    existing.mode = (uint16_t)(BISCUITFS_IFDIR | (st.st_mode & 07777));
+                    existing.uid  = (uint16_t)st.st_uid;
+                    existing.gid  = (uint16_t)st.st_gid;
+                    write_inode_host(child_ino, &existing);
                 }
             }
             if (populate_from_dir_recursive(child_ino, src_base, relchild, now) != 0) {
@@ -1131,7 +1143,8 @@ static int populate_from_dir_recursive(uint32_t parent_ino, const char *src_base
                 closedir(d);
                 return -1;
             }
-            if (create_file_host(parent_ino, de->d_name, data, size, now) != 0) {
+            if (create_file_host(parent_ino, de->d_name, data, size, now,
+                                  st.st_mode, (uint32_t)st.st_uid, (uint32_t)st.st_gid) != 0) {
                 fprintf(stderr, "mkfs: create_file_host failed for '%s' under parent ino %u\n", relchild, parent_ino);
                 free(data);
                 closedir(d);

--- a/tools/mkfs_blueyfs.c
+++ b/tools/mkfs_blueyfs.c
@@ -853,6 +853,16 @@ static uint32_t dir_lookup_host(uint32_t dir_ino, const char *name) {
     return 0;
 }
 
+static uint16_t host_id_to_u16(uint32_t host_id, const char *id_kind, const char *path_hint) {
+    if (host_id > UINT16_MAX) {
+        fprintf(stderr,
+                "mkfs: %s %u for '%s' exceeds 65535, mapping to 0\n",
+                id_kind, host_id, path_hint ? path_hint : "(unknown)");
+        return 0;
+    }
+    return (uint16_t)host_id;
+}
+
 static int create_dir_host(uint32_t parent_ino, const char *name, uint32_t now, uint32_t *ino_out,
                            mode_t host_mode, uint32_t host_uid, uint32_t host_gid) {
     uint32_t ino = alloc_inode_host();
@@ -867,8 +877,8 @@ static int create_dir_host(uint32_t parent_ino, const char *name, uint32_t now, 
 
     memset(&inode, 0, sizeof(inode));
     inode.mode = (uint16_t)(BISCUITFS_IFDIR | (host_mode & 07777));
-    inode.uid = (uint16_t)host_uid;
-    inode.gid = (uint16_t)host_gid;
+    inode.uid = host_id_to_u16(host_uid, "uid", name);
+    inode.gid = host_id_to_u16(host_gid, "gid", name);
     inode.links_count = 2;
     inode.atime = now;
     inode.ctime = now;
@@ -925,8 +935,8 @@ static int create_file_host(uint32_t parent_ino, const char *name,
 
     memset(&inode, 0, sizeof(inode));
     inode.mode = (uint16_t)(BISCUITFS_IFREG | (host_mode & 07777));
-    inode.uid = (uint16_t)host_uid;
-    inode.gid = (uint16_t)host_gid;
+    inode.uid = host_id_to_u16(host_uid, "uid", name);
+    inode.gid = host_id_to_u16(host_gid, "gid", name);
     inode.links_count = 1;
     inode.atime = now;
     inode.ctime = now;
@@ -1027,6 +1037,7 @@ static int resolve_install_symlink(const char *install_root,
                                    struct stat *st_out) {
     char target[PATH_MAX];
     char candidate[PATH_MAX];
+    char resolved_path[PATH_MAX];
     ssize_t target_len;
 
     target_len = readlink(link_path, target, sizeof(target) - 1);
@@ -1056,10 +1067,16 @@ static int resolve_install_symlink(const char *install_root,
         snprintf(candidate, sizeof(candidate), "%s/%s", dironly, target);
     }
 
-    if (!realpath(candidate, resolved_out)) {
+    if (!realpath(candidate, resolved_path)) {
         fprintf(stderr, "mkfs: symlink target not found '%s' -> '%s' (skipping)\n", link_path, target);
         return -1;
     }
+
+    if (strlen(resolved_path) + 1 > resolved_out_size) {
+        fprintf(stderr, "mkfs: resolved symlink path too long for buffer '%s' (skipping)\n", link_path);
+        return -1;
+    }
+    memcpy(resolved_out, resolved_path, strlen(resolved_path) + 1);
 
     if (!path_is_within_root(install_root, resolved_out)) {
         fprintf(stderr, "mkfs: symlink escapes install root '%s' -> '%s' (skipping)\n", link_path, target);
@@ -1178,8 +1195,8 @@ static int populate_from_dir_recursive(uint32_t parent_ino, const char *install_
                 biscuitfs_inode_t existing;
                 if (read_inode_host(child_ino, &existing) == 0) {
                     existing.mode = (uint16_t)(BISCUITFS_IFDIR | (st.st_mode & 07777));
-                    existing.uid  = (uint16_t)st.st_uid;
-                    existing.gid  = (uint16_t)st.st_gid;
+                    existing.uid  = host_id_to_u16((uint32_t)st.st_uid, "uid", fullchild);
+                    existing.gid  = host_id_to_u16((uint32_t)st.st_gid, "gid", fullchild);
                     write_inode_host(child_ino, &existing);
                 }
             }

--- a/tools/mkfs_blueyfs.c
+++ b/tools/mkfs_blueyfs.c
@@ -918,7 +918,10 @@ static int create_file_host(uint32_t parent_ino, const char *name,
     size_t offset = 0;
     uint32_t block_index = 0;
 
-    if (!ino) return -1;
+    if (!ino) {
+        fprintf(stderr, "mkfs: alloc_inode_host failed for '%s'\n", name);
+        return -1;
+    }
 
     memset(&inode, 0, sizeof(inode));
     inode.mode = (uint16_t)(BISCUITFS_IFREG | (host_mode & 07777));
@@ -940,14 +943,20 @@ static int create_file_host(uint32_t parent_ino, const char *name,
         size_t chunk;
         uint32_t metadata_blocks_added = 0;
 
-        if (!blk) return -1;
+        if (!blk) {
+            fprintf(stderr, "mkfs: alloc_block_host failed for '%s' at file block %u\n", name, block_index);
+            return -1;
+        }
 
         memset(blkbuf, 0, sizeof(blkbuf));
         chunk = remaining > sizeof(blkbuf) ? sizeof(blkbuf) : remaining;
         memcpy(blkbuf, data + offset, chunk);
         write_block(blk, blkbuf);
 
-        if (inode_set_block_host(&inode, block_index, blk, &metadata_blocks_added) != 0) return -1;
+        if (inode_set_block_host(&inode, block_index, blk, &metadata_blocks_added) != 0) {
+            fprintf(stderr, "mkfs: inode_set_block_host failed for '%s' at file block %u\n", name, block_index);
+            return -1;
+        }
 
         inode.blocks_lo += (uint32_t)((1u + metadata_blocks_added) * (g_block_size / HOST_SECTOR_SIZE));
         offset += chunk;
@@ -955,8 +964,15 @@ static int create_file_host(uint32_t parent_ino, const char *name,
         block_index++;
     }
 
-    if (write_inode_host(ino, &inode) != 0) return -1;
-    return dir_add_entry_host(parent_ino, name, ino, BISCUITFS_FT_REG_FILE);
+    if (write_inode_host(ino, &inode) != 0) {
+        fprintf(stderr, "mkfs: write_inode_host failed for '%s' (ino=%u)\n", name, ino);
+        return -1;
+    }
+    if (dir_add_entry_host(parent_ino, name, ino, BISCUITFS_FT_REG_FILE) != 0) {
+        fprintf(stderr, "mkfs: dir_add_entry_host failed for '%s' in parent ino %u\n", name, parent_ino);
+        return -1;
+    }
+    return 0;
 }
 
 static int read_host_file(const char *path, uint8_t **data_out, size_t *size_out) {
@@ -995,7 +1011,68 @@ static int read_host_file(const char *path, uint8_t **data_out, size_t *size_out
     return 0;
 }
 
-static int populate_from_dir_recursive(uint32_t parent_ino, const char *src_base, const char *relpath, uint32_t now);
+static int populate_from_dir_recursive(uint32_t parent_ino, const char *install_root, const char *host_dir, uint32_t now);
+
+static int path_is_within_root(const char *root_path, const char *candidate_path) {
+    size_t root_len = strlen(root_path);
+
+    if (strncmp(root_path, candidate_path, root_len) != 0) return 0;
+    return candidate_path[root_len] == '\0' || candidate_path[root_len] == '/';
+}
+
+static int resolve_install_symlink(const char *install_root,
+                                   const char *link_path,
+                                   char *resolved_out,
+                                   size_t resolved_out_size,
+                                   struct stat *st_out) {
+    char target[PATH_MAX];
+    char candidate[PATH_MAX];
+    ssize_t target_len;
+
+    target_len = readlink(link_path, target, sizeof(target) - 1);
+    if (target_len <= 0) {
+        fprintf(stderr, "mkfs: readlink('%s') failed or empty\n", link_path);
+        return -1;
+    }
+    target[target_len] = '\0';
+
+    if (target[0] == '/') {
+        snprintf(candidate, sizeof(candidate), "%s%s", install_root, target);
+    } else {
+        char dironly[PATH_MAX];
+        char *slash;
+
+        if (strlen(link_path) >= sizeof(dironly)) {
+            fprintf(stderr, "mkfs: path too long, skipping symlink '%s'\n", link_path);
+            return -1;
+        }
+
+        strncpy(dironly, link_path, sizeof(dironly) - 1);
+        dironly[sizeof(dironly) - 1] = '\0';
+        slash = strrchr(dironly, '/');
+        if (slash) *slash = '\0';
+        else strcpy(dironly, ".");
+
+        snprintf(candidate, sizeof(candidate), "%s/%s", dironly, target);
+    }
+
+    if (!realpath(candidate, resolved_out)) {
+        fprintf(stderr, "mkfs: symlink target not found '%s' -> '%s' (skipping)\n", link_path, target);
+        return -1;
+    }
+
+    if (!path_is_within_root(install_root, resolved_out)) {
+        fprintf(stderr, "mkfs: symlink escapes install root '%s' -> '%s' (skipping)\n", link_path, target);
+        return -1;
+    }
+
+    if (stat(resolved_out, st_out) != 0) {
+        fprintf(stderr, "mkfs: stat('%s') failed: %s\n", resolved_out, strerror(errno));
+        return -1;
+    }
+
+    return 0;
+}
 
 static int populate_standard_layout(const char *init_path, const char *fstab_path, const char *install_dir) {
     biscuitfs_super_t sb;
@@ -1033,7 +1110,14 @@ static int populate_standard_layout(const char *init_path, const char *fstab_pat
     /* If an install_dir is provided, recursively copy its contents into
      * the new filesystem root preserving relative paths. */
     if (install_dir && install_dir[0] != '\0') {
-        if (populate_from_dir_recursive(BISCUITFS_ROOT_INO, install_dir, "", now) != 0) return -1;
+        char install_root[PATH_MAX];
+
+        if (!realpath(install_dir, install_root)) {
+            fprintf(stderr, "mkfs: realpath('%s') failed: %s\n", install_dir, strerror(errno));
+            return -1;
+        }
+
+        if (populate_from_dir_recursive(BISCUITFS_ROOT_INO, install_root, install_root, now) != 0) return -1;
     }
 
     return 0;
@@ -1045,28 +1129,20 @@ static int populate_standard_layout(const char *init_path, const char *fstab_pat
  * relpath: path within src_base for current recursion (empty for top-level)
  * parent_ino: inode number of the directory in the image where entries are added
  * -------------------------------------------------------------------------*/
-static int populate_from_dir_recursive(uint32_t parent_ino, const char *src_base, const char *relpath, uint32_t now) {
-    char path[PATH_MAX];
-    if (relpath && relpath[0])
-        snprintf(path, sizeof(path), "%s/%s", src_base, relpath);
-    else
-        snprintf(path, sizeof(path), "%s", src_base);
-
-    DIR *d = opendir(path);
+static int populate_from_dir_recursive(uint32_t parent_ino, const char *install_root, const char *host_dir, uint32_t now) {
+    DIR *d = opendir(host_dir);
     if (!d) {
-        fprintf(stderr, "mkfs: opendir('%s') failed: %s\n", path, strerror(errno));
+        fprintf(stderr, "mkfs: opendir('%s') failed: %s\n", host_dir, strerror(errno));
         return -1;
     }
     struct dirent *de;
 
     while ((de = readdir(d)) != NULL) {
         if (strcmp(de->d_name, ".") == 0 || strcmp(de->d_name, "..") == 0) continue;
-        char relchild[PATH_MAX];
-        if (relpath && relpath[0]) snprintf(relchild, sizeof(relchild), "%s/%s", relpath, de->d_name);
-        else snprintf(relchild, sizeof(relchild), "%s", de->d_name);
-
         char fullchild[PATH_MAX];
-        snprintf(fullchild, sizeof(fullchild), "%s/%s", src_base, relchild);
+        const char *source_path = fullchild;
+        char resolved_source[PATH_MAX];
+        snprintf(fullchild, sizeof(fullchild), "%s/%s", host_dir, de->d_name);
 
         struct stat st;
         /* Use lstat to detect symlinks without following them */
@@ -1076,37 +1152,14 @@ static int populate_from_dir_recursive(uint32_t parent_ino, const char *src_base
             return -1;
         }
 
-        /* If it's a symlink, try to resolve and copy the target if present; otherwise skip */
+        /* Resolve symlinks against the install root so absolute links such as
+         * /usr/lib/libc.so stay within the staged sysroot instead of following
+         * the host filesystem. */
         if (S_ISLNK(st.st_mode)) {
-            char tbuf[PATH_MAX];
-            ssize_t tl = readlink(fullchild, tbuf, sizeof(tbuf) - 1);
-            if (tl <= 0) {
-                fprintf(stderr, "mkfs: readlink('%s') failed or empty\n", fullchild);
+            if (resolve_install_symlink(install_root, fullchild, resolved_source, sizeof(resolved_source), &st) != 0) {
                 continue;
             }
-            tbuf[tl] = '\0';
-            char resolved[PATH_MAX];
-            /* If the link is absolute, use it; otherwise resolve relative to the symlink's dir */
-            if (tbuf[0] == '/') {
-                snprintf(resolved, sizeof(resolved), "%s", tbuf);
-            } else {
-                /* dirname(fullchild) + '/' + tbuf */
-                char dironly[PATH_MAX];
-                if (strlen(fullchild) >= sizeof(dironly)) {
-                    fprintf(stderr, "mkfs: path too long, skipping symlink '%s'\n", fullchild);
-                    continue;
-                }
-                strncpy(dironly, fullchild, sizeof(dironly) - 1);
-                dironly[sizeof(dironly) - 1] = '\0';
-                char *p = strrchr(dironly, '/');
-                if (p) *p = '\0'; else dironly[0] = '.'; 
-                snprintf(resolved, sizeof(resolved), "%s/%s", dironly, tbuf);
-            }
-            if (stat(resolved, &st) != 0) {
-                fprintf(stderr, "mkfs: symlink target not found '%s' -> '%s' (skipping)\n", fullchild, tbuf);
-                continue;
-            }
-            /* proceed using st for the resolved target */
+            source_path = resolved_source;
         }
 
         if (S_ISDIR(st.st_mode)) {
@@ -1116,7 +1169,7 @@ static int populate_from_dir_recursive(uint32_t parent_ino, const char *src_base
             if (!child_ino) {
                 if (create_dir_host(parent_ino, de->d_name, now, &child_ino,
                                     st.st_mode, (uint32_t)st.st_uid, (uint32_t)st.st_gid) != 0) {
-                    fprintf(stderr, "mkfs: create_dir_host failed for '%s' under parent ino %u\n", relchild, parent_ino);
+                    fprintf(stderr, "mkfs: create_dir_host failed for '%s' under parent ino %u\n", fullchild, parent_ino);
                     closedir(d);
                     return -1;
                 }
@@ -1130,22 +1183,22 @@ static int populate_from_dir_recursive(uint32_t parent_ino, const char *src_base
                     write_inode_host(child_ino, &existing);
                 }
             }
-            if (populate_from_dir_recursive(child_ino, src_base, relchild, now) != 0) {
-                fprintf(stderr, "mkfs: recursion failed for '%s'\n", relchild);
+            if (populate_from_dir_recursive(child_ino, install_root, source_path, now) != 0) {
+                fprintf(stderr, "mkfs: recursion failed for '%s'\n", source_path);
                 closedir(d);
                 return -1;
             }
         } else if (S_ISREG(st.st_mode)) {
             uint8_t *data = NULL;
             size_t size = 0;
-            if (read_host_file(fullchild, &data, &size) != 0) {
-                fprintf(stderr, "mkfs: read_host_file failed for '%s'\n", fullchild);
+            if (read_host_file(source_path, &data, &size) != 0) {
+                fprintf(stderr, "mkfs: read_host_file failed for '%s'\n", source_path);
                 closedir(d);
                 return -1;
             }
             if (create_file_host(parent_ino, de->d_name, data, size, now,
                                   st.st_mode, (uint32_t)st.st_uid, (uint32_t)st.st_gid) != 0) {
-                fprintf(stderr, "mkfs: create_file_host failed for '%s' under parent ino %u\n", relchild, parent_ino);
+                fprintf(stderr, "mkfs: create_file_host failed for '%s' under parent ino %u\n", source_path, parent_ino);
                 free(data);
                 closedir(d);
                 return -1;

--- a/tools/mkfs_blueyfs.c
+++ b/tools/mkfs_blueyfs.c
@@ -1072,11 +1072,12 @@ static int resolve_install_symlink(const char *install_root,
         return -1;
     }
 
-    if (strlen(resolved_path) + 1 > resolved_out_size) {
+    size_t resolved_len = strlen(resolved_path);
+    if (resolved_len + 1 > resolved_out_size) {
         fprintf(stderr, "mkfs: resolved symlink path too long for buffer '%s' (skipping)\n", link_path);
         return -1;
     }
-    memcpy(resolved_out, resolved_path, strlen(resolved_path) + 1);
+    memcpy(resolved_out, resolved_path, resolved_len + 1);
 
     if (!path_is_within_root(install_root, resolved_out)) {
         fprintf(stderr, "mkfs: symlink escapes install root '%s' -> '%s' (skipping)\n", link_path, target);


### PR DESCRIPTION
This pull request introduces a new in-memory device filesystem (`devfs`) for `/dev`, improves the build system to support both legacy and musl-based init binaries, and increases open file table limits for several filesystems. These changes improve device node support, build flexibility, and system scalability.

**New device filesystem:**
* Added a new `devfs` implementation (`fs/devfs.c`, `fs/devfs.h`) that provides a synthetic `/dev` with common device nodes (e.g., `null`, `zero`, `random`, `tty`, disks, network interfaces) without requiring `mknod` or a writable root. This makes `/dev` available early and on read-only filesystems. [[1]](diffhunk://#diff-5f39618e8ffdbe83856238ef1017204c440d0d7c9a3b95b992f77e152e2797fdR1-R341) [[2]](diffhunk://#diff-cd2e1164886e3c40a06f056ef755ceab9c29dec5900043bf6c663bd11b5f21e4R1-R15)
* Integrated `devfs` into the build by adding it to the kernel sources list (`Makefile`).

**Build system improvements:**
* Refactored the `Makefile` to support both legacy (`init.elf`) and musl-based (`init-musl.elf`) init binaries, with improved sysroot and disk image assembly logic. The build now uses a more flexible sysroot source and provides options for disk image erasure. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R83-R95) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L322-R329) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L415-R421) [[4]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L478-R472) [[5]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L542-R540)

**Filesystem scalability:**
* Increased open file table limits from 8/16 to 1024 for `blueyfs`, `fat`, and `procfs`, allowing more simultaneous file handles and improving system robustness under heavy load. [[1]](diffhunk://#diff-b94283b09cc92e7c0f28841eae43ffe194b3c42779624f41f54485118d307a08L60-R60) [[2]](diffhunk://#diff-5388257958ebd8a3b68243d60034152621644c275848bc35227b62419e9f71d9L27-R27) [[3]](diffhunk://#diff-e1872e761edd2e42095a6c67ded51d6272ef6dcab0ee294df02e080f2a33b37fL7-R7)

**Other improvements:**
* Minor codebase hygiene: included missing header (`kheap.h`) in `fs/vfs.c` and refactored the static file descriptor table for flexibility. [[1]](diffhunk://#diff-a7e9fd1f0d495a638bc65a71f212d20f63709b725156ce317ca46d6a121fe9ceR11) [[2]](diffhunk://#diff-a7e9fd1f0d495a638bc65a71f212d20f63709b725156ce317ca46d6a121fe9ceL42-R46)