### PR TITLE
Implement netctl message handlers for address and route management

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,16 +12,21 @@
 
 ## Ecosystem repos
 
-| Repo | Role |
-|------|------|
-| **nzmacgeek/biscuits** | i386 kernel, VFS, syscalls, drivers |
-| **nzmacgeek/claw** | PID 1 init daemon |
-| **nzmacgeek/walkies** | Network configuration (netctl client) |
-| **nzmacgeek/scout** | DHCP and DNS client daemon |
-| **nzmacgeek/yap** | Syslog daemon |
-| **nzmacgeek/dimsim** | Package manager |
-| **nzmacgeek/musl-blueyos** | musl libc for BlueyOS |
-| **nzmacgeek/blueyos-bash** | Bash 5 for BlueyOS |
+The authoritative repo-purpose mapping lives in `AGENT_INSTRUCTIONS.md`. Use the
+list below as a quick repo index only, and refer to the root instructions file
+for each repo's current purpose/role.
+
+| Repo |
+|------|
+| `nzmacgeek/biscuits` |
+| `nzmacgeek/claw` |
+| `nzmacgeek/matey` |
+| `nzmacgeek/walkies` |
+| `nzmacgeek/yap` |
+| `nzmacgeek/dimsim` |
+| `nzmacgeek/musl-blueyos` |
+| `nzmacgeek/blueyos-bash` |
+| `nzmacgeek/scout` |
 
 ## Key conventions
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,45 @@
+# GitHub Copilot Instructions — BlueyOS / biscuits
+
+> This is a **kernel research project** for BlueyOS, a Linux-like OS for i386.
+> Read [AGENT_INSTRUCTIONS.md](../AGENT_INSTRUCTIONS.md) for the full picture.
+
+## Quick reference
+
+- Kernel: C11, freestanding, 4-space indent, no libc
+- Network control: `AF_BLUEY_NETCTL` sockets (not ioctl, not Linux Netlink)
+- Build: `make` (kernel ELF), `make disk-musl` (bootable image), `make run` (QEMU)
+- Verbosity: `syslog_get_verbose()` / `VERBOSE_QUIET=0`, `VERBOSE_INFO=1`, `VERBOSE_DEBUG=2`
+
+## Ecosystem repos
+
+| Repo | Role |
+|------|------|
+| **nzmacgeek/biscuits** | i386 kernel, VFS, syscalls, drivers |
+| **nzmacgeek/claw** | PID 1 init daemon |
+| **nzmacgeek/walkies** | Network configuration (netctl client) |
+| **nzmacgeek/scout** | DHCP and DNS client daemon |
+| **nzmacgeek/yap** | Syslog daemon |
+| **nzmacgeek/dimsim** | Package manager |
+| **nzmacgeek/musl-blueyos** | musl libc for BlueyOS |
+| **nzmacgeek/blueyos-bash** | Bash 5 for BlueyOS |
+
+## Key conventions
+
+- All new syscalls: add to `kernel/syscall.h` AND `kernel/syscall.c` dispatch table
+- Network: use `netctl` control plane only — no hard-coded IP config in kernel
+- DHCP: handled by **scout** userspace daemon via netctl
+- When fixing a defect, add an entry to `docs/DEFECT_ANALYSIS.md`
+- Store useful facts with `store_memory` so future agents benefit
+
+## Network stack
+
+The kernel provides `AF_BLUEY_NETCTL` sockets for network configuration.
+Userspace tools (walkies, scout) use `socket(AF_BLUEY_NETCTL, SOCK_NETCTL, 0)`.
+
+Control plane message flow:
+1. Userspace sends `NETCTL_MSG_*` request via `sendmsg()`
+2. Kernel processes in `netctl_process_message()`
+3. Kernel responds or sends multicast notification
+4. Userspace reads response via `recvmsg()`
+
+See `kernel/netctl.h` and `net/design.md` for protocol details.

--- a/AGENT_INSTRUCTIONS.md
+++ b/AGENT_INSTRUCTIONS.md
@@ -16,7 +16,8 @@ repos and consult the relevant repo:
 | **nzmacgeek/biscuits** | i386 kernel, VFS, syscalls, drivers | `kernel/`, `drivers/`, `fs/`, `net/` |
 | **nzmacgeek/claw** | PID 1 init daemon (service manager) | `src/claw/main.c`, `src/core/service/supervisor.c` |
 | **nzmacgeek/matey** | getty / login prompt | `matey.c` |
-| **nzmacgeek/walkies** | Network configuration tool (netctl) | see WALKIES_PROMPT.md in biscuits |
+| **nzmacgeek/walkies** | Network configuration tool (netctl) | `src/walkies.c`, or see WALKIES_PROMPT.md in biscuits |
+| **nzmacgeek/scout** | DHCP and DNS client daemon | `src/`, key files TBD |
 | **nzmacgeek/yap** | Syslog daemon / log rotation | `yap.c` (or equivalent) |
 | **nzmacgeek/dimsim** | Package manager / firstboot scripts | `cmd/`, `internal/`, `template/` |
 | **nzmacgeek/musl-blueyos** | musl libc patched for BlueyOS syscalls | `arch/i386/`, `src/` |
@@ -24,6 +25,8 @@ repos and consult the relevant repo:
 
 **When working on a kernel syscall, always check musl-blueyos and blueyos-bash
 to understand the caller expectations.**
+
+**When working on DHCP/DNS client, coordinate with scout**. Scout is a userspace daemon that uses the netctl control plane (AF_BLUEY_NETCTL sockets) to implement DHCP and DNS resolution for BlueyOS.
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -433,6 +433,9 @@ disk-musl: $(TARGET) $(MUSL_INIT_TARGET) $(RESCUE_SH_TARGET) ensure-disk-sysroot
 fat-log-disk:
 	@bash tools/mkfat_logs_disk.sh "$(LOG_DISK_IMAGE)"
 
+extract-var-log:
+	@$(PYTHON) tools/extract_var_log.py --image "$(DISK_IMAGE)" --output-dir debug/var-log
+
 run: disk ; @if [ "$(ARCH)" != "i386" ]; then echo "  [RUN]  QEMU run is only supported for ARCH=i386"; exit 1; fi; BUILD_DIR=$(BUILD_DIR) bash tools/qemu-run.sh
 
 run-m68k: $(BUILD_DIR)/blueyos-m68k.elf

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ make BUILD_NUMBER=42   # Build with a specific build number
 make iso               # Create bootable ISO
 make disk              # Create build/blueyos-disk.img with BlueyFS root + swap
 make run               # Launch in QEMU
+make extract-var-log   # Extract /var/log from build/blueyos-disk.img to debug/var-log
 make version           # Print version info
 make clean             # Clean build artifacts
 ```
@@ -124,6 +125,7 @@ Host-side filesystem tools:
 ```bash
 make tools-host
 ./build/tools/fsck_blueyfs -o 67584 build/blueyos-disk.img   # 67584 = default BlueyFS root partition LBA
+make extract-var-log                                         # Host helper for /var/log extraction
 ```
 
 The default disk layout is:
@@ -136,6 +138,15 @@ GRUB now boots with `root=/dev/hda2 rootfstype=blueyfs`, and the kernel reads `/
 after mounting root to enable swap and any additional simple mounts. The full loader-provided
 kernel command line is also preserved in `/proc/cmdline`, so Claw-specific boot options such as
 `claw.target=multi-user` or `claw.single=1` should be passed directly on the kernel command line.
+Generated GRUB entries default to `verbose=2` for debug-friendly boot logging.
+
+## Networking control plane (`netctl`)
+
+The `AF_BLUEY_NETCTL` / `SOCK_NETCTL` control-plane socket in the kernel supports:
+
+- Netdev list/get/set
+- Address add/del/list (IPv4)
+- Route add/del/list (IPv4)
 
 See [TESTING.md](TESTING.md) for detailed testing instructions and expected output.
 

--- a/kernel/netctl.c
+++ b/kernel/netctl.c
@@ -328,6 +328,7 @@ static int netctl_handle_netdev_set(const netctl_msg_header_t *req,
 
     while (remaining >= sizeof(netctl_attr_header_t)) {
         const netctl_attr_header_t *attr = (const netctl_attr_header_t *)attr_data;
+        if (attr->attr_len < NETCTL_ATTR_HDRLEN) break;
         const uint8_t *payload = attr_data + sizeof(netctl_attr_header_t);
 
         if (attr->attr_type == NETCTL_ATTR_IFINDEX && attr->attr_len >= sizeof(netctl_attr_header_t) + sizeof(uint32_t)) {
@@ -401,9 +402,8 @@ static int netctl_handle_addr_new(const netctl_msg_header_t *req,
             prefix_len = *payload;
         }
 
-        if (attr->attr_len < NETCTL_ATTR_HDRLEN) break;
         uint16_t aligned_len = NETCTL_ATTR_ALIGN(attr->attr_len);
-        if (aligned_len == 0 || aligned_len > remaining) break;
+        if (aligned_len > remaining) break;
         attr_data += aligned_len;
         remaining -= aligned_len;
     }
@@ -452,6 +452,7 @@ static int netctl_handle_addr_del(const netctl_msg_header_t *req,
 
     while (remaining >= sizeof(netctl_attr_header_t)) {
         const netctl_attr_header_t *attr = (const netctl_attr_header_t *)attr_data;
+        if (attr->attr_len < NETCTL_ATTR_HDRLEN) break;
         const uint8_t *payload = attr_data + sizeof(netctl_attr_header_t);
 
         if (attr->attr_type == NETCTL_ATTR_IFINDEX && attr->attr_len >= sizeof(netctl_attr_header_t) + sizeof(uint32_t)) {
@@ -462,9 +463,8 @@ static int netctl_handle_addr_del(const netctl_msg_header_t *req,
             memcpy(&addr_value, payload, sizeof(uint32_t));
         }
 
-        if (attr->attr_len < NETCTL_ATTR_HDRLEN) break;
         uint16_t aligned_len = NETCTL_ATTR_ALIGN(attr->attr_len);
-        if (aligned_len == 0 || aligned_len > remaining) break;
+        if (aligned_len > remaining) break;
         attr_data += aligned_len;
         remaining -= aligned_len;
     }
@@ -501,6 +501,7 @@ static int netctl_handle_addr_list(const netctl_msg_header_t *req,
 
     while (remaining >= sizeof(netctl_attr_header_t)) {
         const netctl_attr_header_t *attr = (const netctl_attr_header_t *)attr_data;
+        if (attr->attr_len < NETCTL_ATTR_HDRLEN) break;
         const uint8_t *payload = attr_data + sizeof(netctl_attr_header_t);
 
         if (attr->attr_type == NETCTL_ATTR_IFINDEX &&
@@ -508,9 +509,8 @@ static int netctl_handle_addr_list(const netctl_msg_header_t *req,
             memcpy(&ifindex, payload, sizeof(uint32_t));
         }
 
-        if (attr->attr_len < NETCTL_ATTR_HDRLEN) break;
         uint16_t aligned_len = NETCTL_ATTR_ALIGN(attr->attr_len);
-        if (aligned_len == 0 || aligned_len > remaining) break;
+        if (aligned_len > remaining) break;
         attr_data += aligned_len;
         remaining -= aligned_len;
     }
@@ -571,6 +571,7 @@ static int netctl_handle_route_new(const netctl_msg_header_t *req,
 
     while (remaining >= sizeof(netctl_attr_header_t)) {
         const netctl_attr_header_t *attr = (const netctl_attr_header_t *)attr_data;
+        if (attr->attr_len < NETCTL_ATTR_HDRLEN) break;
         const uint8_t *payload = attr_data + sizeof(netctl_attr_header_t);
 
         if (attr->attr_type == NETCTL_ATTR_ROUTE_FAMILY &&
@@ -594,9 +595,8 @@ static int netctl_handle_route_new(const netctl_msg_header_t *req,
             memcpy(&metric, payload, sizeof(uint32_t));
         }
 
-        if (attr->attr_len < NETCTL_ATTR_HDRLEN) break;
         uint16_t aligned_len = NETCTL_ATTR_ALIGN(attr->attr_len);
-        if (aligned_len == 0 || aligned_len > remaining) break;
+        if (aligned_len > remaining) break;
         attr_data += aligned_len;
         remaining -= aligned_len;
     }
@@ -642,6 +642,7 @@ static int netctl_handle_route_del(const netctl_msg_header_t *req,
 
     while (remaining >= sizeof(netctl_attr_header_t)) {
         const netctl_attr_header_t *attr = (const netctl_attr_header_t *)attr_data;
+        if (attr->attr_len < NETCTL_ATTR_HDRLEN) break;
         const uint8_t *payload = attr_data + sizeof(netctl_attr_header_t);
 
         if (attr->attr_type == NETCTL_ATTR_ROUTE_FAMILY &&
@@ -656,9 +657,8 @@ static int netctl_handle_route_del(const netctl_msg_header_t *req,
             prefix_len = *payload;
         }
 
-        if (attr->attr_len < NETCTL_ATTR_HDRLEN) break;
         uint16_t aligned_len = NETCTL_ATTR_ALIGN(attr->attr_len);
-        if (aligned_len == 0 || aligned_len > remaining) break;
+        if (aligned_len > remaining) break;
         attr_data += aligned_len;
         remaining -= aligned_len;
     }

--- a/kernel/netctl.c
+++ b/kernel/netctl.c
@@ -384,6 +384,7 @@ static int netctl_handle_addr_new(const netctl_msg_header_t *req,
     uint16_t family = NETDEV_AF_INET;
     uint32_t addr_value = 0;
     uint8_t prefix_len = 0;
+    int has_addr = 0;
 
     while (remaining >= sizeof(netctl_attr_header_t)) {
         const netctl_attr_header_t *attr = (const netctl_attr_header_t *)attr_data;
@@ -395,12 +396,14 @@ static int netctl_handle_addr_new(const netctl_msg_header_t *req,
             memcpy(&family, payload, sizeof(uint16_t));
         } else if (attr->attr_type == NETCTL_ATTR_ADDR_VALUE && attr->attr_len >= sizeof(netctl_attr_header_t) + sizeof(uint32_t)) {
             memcpy(&addr_value, payload, sizeof(uint32_t));
+            has_addr = 1;
         } else if (attr->attr_type == NETCTL_ATTR_ADDR_PREFIX && attr->attr_len >= sizeof(netctl_attr_header_t) + sizeof(uint8_t)) {
             prefix_len = *payload;
         }
 
+        if (attr->attr_len < NETCTL_ATTR_HDRLEN) break;
         uint16_t aligned_len = NETCTL_ATTR_ALIGN(attr->attr_len);
-        if (aligned_len > remaining) break;
+        if (aligned_len == 0 || aligned_len > remaining) break;
         attr_data += aligned_len;
         remaining -= aligned_len;
     }
@@ -408,6 +411,21 @@ static int netctl_handle_addr_new(const netctl_msg_header_t *req,
     if (ifindex == 0) {
         return netctl_build_error(response, response_maxlen, req->msg_seq,
                                   -1, "No ifindex specified");
+    }
+
+    if (family != NETDEV_AF_INET) {
+        return netctl_build_error(response, response_maxlen, req->msg_seq,
+                                  -1, "Unsupported address family");
+    }
+
+    if (!has_addr) {
+        return netctl_build_error(response, response_maxlen, req->msg_seq,
+                                  -1, "No address specified");
+    }
+
+    if (prefix_len > 32) {
+        return netctl_build_error(response, response_maxlen, req->msg_seq,
+                                  -1, "Invalid IPv4 prefix length");
     }
 
     if (netdev_addr_add(ifindex, (uint16_t)family, &addr_value, prefix_len) < 0) {
@@ -444,8 +462,9 @@ static int netctl_handle_addr_del(const netctl_msg_header_t *req,
             memcpy(&addr_value, payload, sizeof(uint32_t));
         }
 
+        if (attr->attr_len < NETCTL_ATTR_HDRLEN) break;
         uint16_t aligned_len = NETCTL_ATTR_ALIGN(attr->attr_len);
-        if (aligned_len > remaining) break;
+        if (aligned_len == 0 || aligned_len > remaining) break;
         attr_data += aligned_len;
         remaining -= aligned_len;
     }
@@ -453,6 +472,11 @@ static int netctl_handle_addr_del(const netctl_msg_header_t *req,
     if (ifindex == 0) {
         return netctl_build_error(response, response_maxlen, req->msg_seq,
                                   -1, "No ifindex specified");
+    }
+
+    if (family != NETDEV_AF_INET) {
+        return netctl_build_error(response, response_maxlen, req->msg_seq,
+                                  -1, "Unsupported address family");
     }
 
     if (netdev_addr_del(ifindex, (uint16_t)family, &addr_value) < 0) {
@@ -484,6 +508,7 @@ static int netctl_handle_addr_list(const netctl_msg_header_t *req,
             memcpy(&ifindex, payload, sizeof(uint32_t));
         }
 
+        if (attr->attr_len < NETCTL_ATTR_HDRLEN) break;
         uint16_t aligned_len = NETCTL_ATTR_ALIGN(attr->attr_len);
         if (aligned_len == 0 || aligned_len > remaining) break;
         attr_data += aligned_len;
@@ -569,6 +594,7 @@ static int netctl_handle_route_new(const netctl_msg_header_t *req,
             memcpy(&metric, payload, sizeof(uint32_t));
         }
 
+        if (attr->attr_len < NETCTL_ATTR_HDRLEN) break;
         uint16_t aligned_len = NETCTL_ATTR_ALIGN(attr->attr_len);
         if (aligned_len == 0 || aligned_len > remaining) break;
         attr_data += aligned_len;
@@ -578,6 +604,16 @@ static int netctl_handle_route_new(const netctl_msg_header_t *req,
     if (!has_dest) {
         return netctl_build_error(response, response_maxlen, req->msg_seq,
                                   -1, "No destination specified");
+    }
+
+    if (family != NETDEV_AF_INET) {
+        return netctl_build_error(response, response_maxlen, req->msg_seq,
+                                  -1, "Unsupported route family");
+    }
+
+    if (prefix_len > 32) {
+        return netctl_build_error(response, response_maxlen, req->msg_seq,
+                                  -1, "Invalid IPv4 prefix length");
     }
 
     const void *gw_ptr = gateway ? &gateway : NULL;
@@ -620,6 +656,7 @@ static int netctl_handle_route_del(const netctl_msg_header_t *req,
             prefix_len = *payload;
         }
 
+        if (attr->attr_len < NETCTL_ATTR_HDRLEN) break;
         uint16_t aligned_len = NETCTL_ATTR_ALIGN(attr->attr_len);
         if (aligned_len == 0 || aligned_len > remaining) break;
         attr_data += aligned_len;
@@ -629,6 +666,16 @@ static int netctl_handle_route_del(const netctl_msg_header_t *req,
     if (!has_dest) {
         return netctl_build_error(response, response_maxlen, req->msg_seq,
                                   -1, "No destination specified");
+    }
+
+    if (family != NETDEV_AF_INET) {
+        return netctl_build_error(response, response_maxlen, req->msg_seq,
+                                  -1, "Unsupported route family");
+    }
+
+    if (prefix_len > 32) {
+        return netctl_build_error(response, response_maxlen, req->msg_seq,
+                                  -1, "Invalid IPv4 prefix length");
     }
 
     if (netdev_route_del(family, &dest, prefix_len) < 0) {

--- a/kernel/netctl.c
+++ b/kernel/netctl.c
@@ -372,6 +372,317 @@ static int netctl_handle_netdev_set(const netctl_msg_header_t *req,
     return (int)resp->msg_len;
 }
 
+// Helper: Process ADDR_NEW request
+static int netctl_handle_addr_new(const netctl_msg_header_t *req,
+                                   const void *msg, size_t len,
+                                   void *response, size_t response_maxlen) {
+    (void)len;
+
+    const uint8_t *attr_data = (const uint8_t *)msg + sizeof(netctl_msg_header_t);
+    uint32_t remaining = req->msg_len - sizeof(netctl_msg_header_t);
+    uint32_t ifindex = 0;
+    uint16_t family = NETDEV_AF_INET;
+    uint32_t addr_value = 0;
+    uint8_t prefix_len = 0;
+
+    while (remaining >= sizeof(netctl_attr_header_t)) {
+        const netctl_attr_header_t *attr = (const netctl_attr_header_t *)attr_data;
+        const uint8_t *payload = attr_data + sizeof(netctl_attr_header_t);
+
+        if (attr->attr_type == NETCTL_ATTR_IFINDEX && attr->attr_len >= sizeof(netctl_attr_header_t) + sizeof(uint32_t)) {
+            memcpy(&ifindex, payload, sizeof(uint32_t));
+        } else if (attr->attr_type == NETCTL_ATTR_ADDR_FAMILY && attr->attr_len >= sizeof(netctl_attr_header_t) + sizeof(uint16_t)) {
+            memcpy(&family, payload, sizeof(uint16_t));
+        } else if (attr->attr_type == NETCTL_ATTR_ADDR_VALUE && attr->attr_len >= sizeof(netctl_attr_header_t) + sizeof(uint32_t)) {
+            memcpy(&addr_value, payload, sizeof(uint32_t));
+        } else if (attr->attr_type == NETCTL_ATTR_ADDR_PREFIX && attr->attr_len >= sizeof(netctl_attr_header_t) + sizeof(uint8_t)) {
+            prefix_len = *payload;
+        }
+
+        uint16_t aligned_len = NETCTL_ATTR_ALIGN(attr->attr_len);
+        if (aligned_len > remaining) break;
+        attr_data += aligned_len;
+        remaining -= aligned_len;
+    }
+
+    if (ifindex == 0) {
+        return netctl_build_error(response, response_maxlen, req->msg_seq,
+                                  -1, "No ifindex specified");
+    }
+
+    if (netdev_addr_add(ifindex, (uint16_t)family, &addr_value, prefix_len) < 0) {
+        return netctl_build_error(response, response_maxlen, req->msg_seq,
+                                  -1, "Failed to add address");
+    }
+
+    netctl_msg_header_t *resp = (netctl_msg_header_t *)response;
+    netctl_msg_init(resp, NETCTL_MSG_DONE, 0, req->msg_seq, 0);
+    return (int)resp->msg_len;
+}
+
+// Helper: Process ADDR_DEL request
+static int netctl_handle_addr_del(const netctl_msg_header_t *req,
+                                   const void *msg, size_t len,
+                                   void *response, size_t response_maxlen) {
+    (void)len;
+
+    const uint8_t *attr_data = (const uint8_t *)msg + sizeof(netctl_msg_header_t);
+    uint32_t remaining = req->msg_len - sizeof(netctl_msg_header_t);
+    uint32_t ifindex = 0;
+    uint16_t family = NETDEV_AF_INET;
+    uint32_t addr_value = 0;
+
+    while (remaining >= sizeof(netctl_attr_header_t)) {
+        const netctl_attr_header_t *attr = (const netctl_attr_header_t *)attr_data;
+        const uint8_t *payload = attr_data + sizeof(netctl_attr_header_t);
+
+        if (attr->attr_type == NETCTL_ATTR_IFINDEX && attr->attr_len >= sizeof(netctl_attr_header_t) + sizeof(uint32_t)) {
+            memcpy(&ifindex, payload, sizeof(uint32_t));
+        } else if (attr->attr_type == NETCTL_ATTR_ADDR_FAMILY && attr->attr_len >= sizeof(netctl_attr_header_t) + sizeof(uint16_t)) {
+            memcpy(&family, payload, sizeof(uint16_t));
+        } else if (attr->attr_type == NETCTL_ATTR_ADDR_VALUE && attr->attr_len >= sizeof(netctl_attr_header_t) + sizeof(uint32_t)) {
+            memcpy(&addr_value, payload, sizeof(uint32_t));
+        }
+
+        uint16_t aligned_len = NETCTL_ATTR_ALIGN(attr->attr_len);
+        if (aligned_len > remaining) break;
+        attr_data += aligned_len;
+        remaining -= aligned_len;
+    }
+
+    if (ifindex == 0) {
+        return netctl_build_error(response, response_maxlen, req->msg_seq,
+                                  -1, "No ifindex specified");
+    }
+
+    if (netdev_addr_del(ifindex, (uint16_t)family, &addr_value) < 0) {
+        return netctl_build_error(response, response_maxlen, req->msg_seq,
+                                  -1, "Failed to delete address");
+    }
+
+    netctl_msg_header_t *resp = (netctl_msg_header_t *)response;
+    netctl_msg_init(resp, NETCTL_MSG_DONE, 0, req->msg_seq, 0);
+    return (int)resp->msg_len;
+}
+
+// Helper: Process ADDR_LIST request
+static int netctl_handle_addr_list(const netctl_msg_header_t *req,
+                                    const void *msg, size_t len,
+                                    void *response, size_t response_maxlen) {
+    (void)len;
+
+    const uint8_t *attr_data = (const uint8_t *)msg + sizeof(netctl_msg_header_t);
+    uint32_t remaining = req->msg_len - sizeof(netctl_msg_header_t);
+    uint32_t ifindex = 0;
+
+    while (remaining >= sizeof(netctl_attr_header_t)) {
+        const netctl_attr_header_t *attr = (const netctl_attr_header_t *)attr_data;
+        const uint8_t *payload = attr_data + sizeof(netctl_attr_header_t);
+
+        if (attr->attr_type == NETCTL_ATTR_IFINDEX &&
+            attr->attr_len >= sizeof(netctl_attr_header_t) + sizeof(uint32_t)) {
+            memcpy(&ifindex, payload, sizeof(uint32_t));
+        }
+
+        uint16_t aligned_len = NETCTL_ATTR_ALIGN(attr->attr_len);
+        if (aligned_len == 0 || aligned_len > remaining) break;
+        attr_data += aligned_len;
+        remaining -= aligned_len;
+    }
+
+    if (ifindex == 0) {
+        return netctl_build_error(response, response_maxlen, req->msg_seq,
+                                  -1, "No ifindex specified");
+    }
+
+    netctl_msg_header_t *resp = (netctl_msg_header_t *)response;
+    netctl_msg_init(resp, NETCTL_MSG_ADDR_LIST, 0, req->msg_seq, 0);
+
+    netdev_addr_t addrs[NETDEV_MAX_ADDRS];
+    int count = netdev_addr_list(ifindex, addrs, NETDEV_MAX_ADDRS);
+
+    for (int i = 0; i < count; i++) {
+        uint8_t entry_buf[128];
+        netctl_msg_header_t *ehdr = (netctl_msg_header_t *)entry_buf;
+        netctl_msg_init(ehdr, 0, 0, 0, 0);
+
+        netctl_msg_add_attr(entry_buf, sizeof(entry_buf),
+                            NETCTL_ATTR_IFINDEX,
+                            &addrs[i].ifindex, sizeof(addrs[i].ifindex));
+        uint16_t fam = addrs[i].family;
+        netctl_msg_add_attr(entry_buf, sizeof(entry_buf),
+                            NETCTL_ATTR_ADDR_FAMILY, &fam, sizeof(fam));
+        netctl_msg_add_attr(entry_buf, sizeof(entry_buf),
+                            NETCTL_ATTR_ADDR_PREFIX,
+                            &addrs[i].prefix_len, sizeof(addrs[i].prefix_len));
+        netctl_msg_add_attr(entry_buf, sizeof(entry_buf),
+                            NETCTL_ATTR_ADDR_VALUE,
+                            &addrs[i].addr.ipv4, sizeof(addrs[i].addr.ipv4));
+
+        const uint8_t *payload = entry_buf + sizeof(netctl_msg_header_t);
+        uint16_t plen = (uint16_t)(ehdr->msg_len - sizeof(netctl_msg_header_t));
+        netctl_msg_add_attr(response, response_maxlen,
+                            NETCTL_ATTR_NESTED, payload, plen);
+    }
+
+    return (int)resp->msg_len;
+}
+
+// Helper: Process ROUTE_NEW request
+static int netctl_handle_route_new(const netctl_msg_header_t *req,
+                                    const void *msg, size_t len,
+                                    void *response, size_t response_maxlen) {
+    (void)len;
+
+    const uint8_t *attr_data = (const uint8_t *)msg + sizeof(netctl_msg_header_t);
+    uint32_t remaining = req->msg_len - sizeof(netctl_msg_header_t);
+    uint16_t family = NETDEV_AF_INET;
+    uint32_t dest = 0;
+    uint8_t prefix_len = 0;
+    uint32_t gateway = 0;
+    uint32_t oif = 0;
+    uint32_t metric = 0;
+    int has_dest = 0;
+
+    while (remaining >= sizeof(netctl_attr_header_t)) {
+        const netctl_attr_header_t *attr = (const netctl_attr_header_t *)attr_data;
+        const uint8_t *payload = attr_data + sizeof(netctl_attr_header_t);
+
+        if (attr->attr_type == NETCTL_ATTR_ROUTE_FAMILY &&
+            attr->attr_len >= sizeof(netctl_attr_header_t) + sizeof(uint16_t)) {
+            memcpy(&family, payload, sizeof(uint16_t));
+        } else if (attr->attr_type == NETCTL_ATTR_ROUTE_DST &&
+                   attr->attr_len >= sizeof(netctl_attr_header_t) + sizeof(uint32_t)) {
+            memcpy(&dest, payload, sizeof(uint32_t));
+            has_dest = 1;
+        } else if (attr->attr_type == NETCTL_ATTR_ROUTE_PREFIX &&
+                   attr->attr_len >= sizeof(netctl_attr_header_t) + sizeof(uint8_t)) {
+            prefix_len = *payload;
+        } else if (attr->attr_type == NETCTL_ATTR_ROUTE_GW &&
+                   attr->attr_len >= sizeof(netctl_attr_header_t) + sizeof(uint32_t)) {
+            memcpy(&gateway, payload, sizeof(uint32_t));
+        } else if (attr->attr_type == NETCTL_ATTR_ROUTE_OIF &&
+                   attr->attr_len >= sizeof(netctl_attr_header_t) + sizeof(uint32_t)) {
+            memcpy(&oif, payload, sizeof(uint32_t));
+        } else if (attr->attr_type == NETCTL_ATTR_ROUTE_METRIC &&
+                   attr->attr_len >= sizeof(netctl_attr_header_t) + sizeof(uint32_t)) {
+            memcpy(&metric, payload, sizeof(uint32_t));
+        }
+
+        uint16_t aligned_len = NETCTL_ATTR_ALIGN(attr->attr_len);
+        if (aligned_len == 0 || aligned_len > remaining) break;
+        attr_data += aligned_len;
+        remaining -= aligned_len;
+    }
+
+    if (!has_dest) {
+        return netctl_build_error(response, response_maxlen, req->msg_seq,
+                                  -1, "No destination specified");
+    }
+
+    const void *gw_ptr = gateway ? &gateway : NULL;
+    if (netdev_route_add(family, &dest, prefix_len, gw_ptr, oif, metric) < 0) {
+        return netctl_build_error(response, response_maxlen, req->msg_seq,
+                                  -1, "Failed to add route");
+    }
+
+    netctl_msg_header_t *resp = (netctl_msg_header_t *)response;
+    netctl_msg_init(resp, NETCTL_MSG_DONE, 0, req->msg_seq, 0);
+    return (int)resp->msg_len;
+}
+
+// Helper: Process ROUTE_DEL request
+static int netctl_handle_route_del(const netctl_msg_header_t *req,
+                                    const void *msg, size_t len,
+                                    void *response, size_t response_maxlen) {
+    (void)len;
+
+    const uint8_t *attr_data = (const uint8_t *)msg + sizeof(netctl_msg_header_t);
+    uint32_t remaining = req->msg_len - sizeof(netctl_msg_header_t);
+    uint16_t family = NETDEV_AF_INET;
+    uint32_t dest = 0;
+    uint8_t prefix_len = 0;
+    int has_dest = 0;
+
+    while (remaining >= sizeof(netctl_attr_header_t)) {
+        const netctl_attr_header_t *attr = (const netctl_attr_header_t *)attr_data;
+        const uint8_t *payload = attr_data + sizeof(netctl_attr_header_t);
+
+        if (attr->attr_type == NETCTL_ATTR_ROUTE_FAMILY &&
+            attr->attr_len >= sizeof(netctl_attr_header_t) + sizeof(uint16_t)) {
+            memcpy(&family, payload, sizeof(uint16_t));
+        } else if (attr->attr_type == NETCTL_ATTR_ROUTE_DST &&
+                   attr->attr_len >= sizeof(netctl_attr_header_t) + sizeof(uint32_t)) {
+            memcpy(&dest, payload, sizeof(uint32_t));
+            has_dest = 1;
+        } else if (attr->attr_type == NETCTL_ATTR_ROUTE_PREFIX &&
+                   attr->attr_len >= sizeof(netctl_attr_header_t) + sizeof(uint8_t)) {
+            prefix_len = *payload;
+        }
+
+        uint16_t aligned_len = NETCTL_ATTR_ALIGN(attr->attr_len);
+        if (aligned_len == 0 || aligned_len > remaining) break;
+        attr_data += aligned_len;
+        remaining -= aligned_len;
+    }
+
+    if (!has_dest) {
+        return netctl_build_error(response, response_maxlen, req->msg_seq,
+                                  -1, "No destination specified");
+    }
+
+    if (netdev_route_del(family, &dest, prefix_len) < 0) {
+        return netctl_build_error(response, response_maxlen, req->msg_seq,
+                                  -1, "Route not found");
+    }
+
+    netctl_msg_header_t *resp = (netctl_msg_header_t *)response;
+    netctl_msg_init(resp, NETCTL_MSG_DONE, 0, req->msg_seq, 0);
+    return (int)resp->msg_len;
+}
+
+// Helper: Process ROUTE_LIST request
+static int netctl_handle_route_list(const netctl_msg_header_t *req,
+                                     void *response, size_t response_maxlen) {
+    netctl_msg_header_t *resp = (netctl_msg_header_t *)response;
+    netctl_msg_init(resp, NETCTL_MSG_ROUTE_LIST, 0, req->msg_seq, 0);
+
+    netdev_route_t routes[NETDEV_MAX_ROUTES];
+    int count = netdev_route_list(routes, NETDEV_MAX_ROUTES);
+
+    for (int i = 0; i < count; i++) {
+        uint8_t entry_buf[192];
+        netctl_msg_header_t *ehdr = (netctl_msg_header_t *)entry_buf;
+        netctl_msg_init(ehdr, 0, 0, 0, 0);
+
+        uint16_t fam = routes[i].family;
+        netctl_msg_add_attr(entry_buf, sizeof(entry_buf),
+                            NETCTL_ATTR_ROUTE_FAMILY, &fam, sizeof(fam));
+        netctl_msg_add_attr(entry_buf, sizeof(entry_buf),
+                            NETCTL_ATTR_ROUTE_DST,
+                            &routes[i].dest.ipv4, sizeof(routes[i].dest.ipv4));
+        netctl_msg_add_attr(entry_buf, sizeof(entry_buf),
+                            NETCTL_ATTR_ROUTE_PREFIX,
+                            &routes[i].prefix_len, sizeof(routes[i].prefix_len));
+        netctl_msg_add_attr(entry_buf, sizeof(entry_buf),
+                            NETCTL_ATTR_ROUTE_GW,
+                            &routes[i].gateway.ipv4, sizeof(routes[i].gateway.ipv4));
+        netctl_msg_add_attr(entry_buf, sizeof(entry_buf),
+                            NETCTL_ATTR_ROUTE_OIF,
+                            &routes[i].oif, sizeof(routes[i].oif));
+        netctl_msg_add_attr(entry_buf, sizeof(entry_buf),
+                            NETCTL_ATTR_ROUTE_METRIC,
+                            &routes[i].metric, sizeof(routes[i].metric));
+
+        const uint8_t *payload = entry_buf + sizeof(netctl_msg_header_t);
+        uint16_t plen = (uint16_t)(ehdr->msg_len - sizeof(netctl_msg_header_t));
+        netctl_msg_add_attr(response, response_maxlen,
+                            NETCTL_ATTR_NESTED, payload, plen);
+    }
+
+    return (int)resp->msg_len;
+}
+
 // Main message dispatcher
 int netctl_process_message(const void *msg, size_t len, void *response,
                            size_t response_maxlen) {
@@ -414,14 +725,22 @@ int netctl_process_message(const void *msg, size_t len, void *response,
             return netctl_handle_netdev_set(hdr, msg, len, response, response_maxlen);
 
         case NETCTL_MSG_ADDR_NEW:
+            return netctl_handle_addr_new(hdr, msg, len, response, response_maxlen);
+
         case NETCTL_MSG_ADDR_DEL:
+            return netctl_handle_addr_del(hdr, msg, len, response, response_maxlen);
+
         case NETCTL_MSG_ADDR_LIST:
+            return netctl_handle_addr_list(hdr, msg, len, response, response_maxlen);
+
         case NETCTL_MSG_ROUTE_NEW:
+            return netctl_handle_route_new(hdr, msg, len, response, response_maxlen);
+
         case NETCTL_MSG_ROUTE_DEL:
+            return netctl_handle_route_del(hdr, msg, len, response, response_maxlen);
+
         case NETCTL_MSG_ROUTE_LIST:
-            // Not yet implemented
-            return netctl_build_error(response, response_maxlen, hdr->msg_seq,
-                                      -1, "Operation not yet implemented");
+            return netctl_handle_route_list(hdr, response, response_maxlen);
 
         default:
             return netctl_build_error(response, response_maxlen, hdr->msg_seq,

--- a/kernel/netctl.h
+++ b/kernel/netctl.h
@@ -104,6 +104,8 @@ typedef struct {
 #define NETCTL_ATTR_ROUTE_GW    31  // Gateway address
 #define NETCTL_ATTR_ROUTE_OIF   32  // Output interface index
 #define NETCTL_ATTR_ROUTE_METRIC 33 // Route metric (uint32_t)
+#define NETCTL_ATTR_ROUTE_PREFIX 34 // Route prefix length (uint8_t)
+#define NETCTL_ATTR_ROUTE_FAMILY 35 // Route address family (uint16_t)
 
 // TLV attribute header
 // attr_len stores the actual attribute length (header + payload), NOT including

--- a/net/design.md
+++ b/net/design.md
@@ -93,14 +93,14 @@ compatibility.
 - [x] Report link state
 
 ### Address Operations
-- [ ] Add address
-- [ ] Remove address
-- [ ] Enumerate addresses per interface
+- [x] Add address
+- [x] Remove address
+- [x] Enumerate addresses per interface
 
 ### Routing Operations
-- [ ] Add route
-- [ ] Remove route
-- [ ] Enumerate routes
+- [x] Add route
+- [x] Remove route
+- [x] Enumerate routes
 
 All operations must be accessible via the Netlink-like socket.
 

--- a/tools/extract_var_log.py
+++ b/tools/extract_var_log.py
@@ -256,10 +256,6 @@ def apply_metadata(dest: Path, inode: Inode, *, follow_symlinks: bool) -> None:
 def safe_child_path(dest: Path, name: str) -> Path:
     if not name or name in (".", "..") or "/" in name or "\\" in name:
         raise ValueError(f"unsafe directory entry name: {name!r}")
-    if os.path.sep and os.path.sep in name:
-        raise ValueError(f"unsafe directory entry name: {name!r}")
-    if os.path.altsep and os.path.altsep in name:
-        raise ValueError(f"unsafe directory entry name: {name!r}")
     return dest / name
 
 

--- a/tools/extract_var_log.py
+++ b/tools/extract_var_log.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import shutil
+import struct
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+SECTOR_SIZE = 512
+BLOCK_SIZE = 4096
+MAGIC = 0xB15C0001
+MBR_ENTRY_OFFSET = 446
+MBR_ENTRY_SIZE = 16
+ROOT_PARTITION_INDEX = 1
+INODE_SIZE = 256
+INODES_PER_GROUP = 8192
+BLOCKS_PER_GROUP = 8192
+ROOT_INO = 2
+N_DIRECT_BLOCKS = 12
+
+IFMT = 0xF000
+IFREG = 0x8000
+IFDIR = 0x4000
+IFLNK = 0xA000
+
+
+@dataclass
+class Inode:
+    mode: int
+    uid: int
+    gid: int
+    size_lo: int
+    size_hi: int
+    atime: int
+    ctime: int
+    mtime: int
+    links_count: int
+    blocks_lo: int
+    block: tuple[int, ...]
+
+    @property
+    def size(self) -> int:
+        return (self.size_hi << 32) | self.size_lo
+
+
+class BlueyFSImage:
+    def __init__(self, image_path: Path, start_sector: int | None = None):
+        self.image_path = image_path
+        self.fp = image_path.open("rb")
+        self.start_sector = start_sector if start_sector is not None else self._read_root_partition_start()
+        self.fs_offset = self.start_sector * SECTOR_SIZE
+        self.block_count, self.inode_count = self._load_superblock()
+        self.num_groups = (self.block_count + BLOCKS_PER_GROUP - 1) // BLOCKS_PER_GROUP
+        self.bgd_table = self._read_exact(self.fs_offset + BLOCK_SIZE, self.num_groups * 32)
+
+    def close(self) -> None:
+        self.fp.close()
+
+    def _read_exact(self, offset: int, size: int) -> bytes:
+        self.fp.seek(offset)
+        data = self.fp.read(size)
+        if len(data) != size:
+            raise ValueError(f"short read at offset {offset} (wanted {size} bytes, got {len(data)})")
+        return data
+
+    def _read_root_partition_start(self) -> int:
+        mbr = self._read_exact(0, SECTOR_SIZE)
+        if mbr[510:512] != b"\x55\xaa":
+            raise ValueError("disk image does not contain a valid MBR; pass --start-sector for raw BlueyFS images")
+
+        entry_offset = MBR_ENTRY_OFFSET + (ROOT_PARTITION_INDEX * MBR_ENTRY_SIZE)
+        entry = mbr[entry_offset:entry_offset + MBR_ENTRY_SIZE]
+        start_lba = struct.unpack_from("<I", entry, 8)[0]
+        sector_count = struct.unpack_from("<I", entry, 12)[0]
+        if start_lba == 0 or sector_count == 0:
+            raise ValueError("root partition entry is empty; pass --start-sector explicitly")
+        return start_lba
+
+    def _load_superblock(self) -> tuple[int, int]:
+        super_block = self._read_exact(self.fs_offset, BLOCK_SIZE)
+        magic = struct.unpack_from("<I", super_block, 1024)[0]
+        if magic != MAGIC:
+            raise ValueError(
+                f"BlueyFS magic mismatch at sector {self.start_sector}: expected 0x{MAGIC:08x}, got 0x{magic:08x}"
+            )
+        block_count = struct.unpack_from("<I", super_block, 1024 + 8)[0]
+        inode_count = struct.unpack_from("<I", super_block, 1024 + 20)[0]
+        return block_count, inode_count
+
+    def _read_block(self, block_no: int) -> bytes:
+        return self._read_exact(self.fs_offset + (block_no * BLOCK_SIZE), BLOCK_SIZE)
+
+    def _bgd_inode_table_block(self, group: int) -> int:
+        if group >= self.num_groups:
+            raise FileNotFoundError(f"inode group {group} is out of range")
+        return struct.unpack_from("<I", self.bgd_table, group * 32 + 8)[0]
+
+    def read_inode(self, inode_no: int) -> Inode:
+        if inode_no == 0 or inode_no > self.inode_count:
+            raise FileNotFoundError(f"inode {inode_no} is out of range")
+
+        inode_index = inode_no - 1
+        group = inode_index // INODES_PER_GROUP
+        local_index = inode_index % INODES_PER_GROUP
+        inodes_per_block = BLOCK_SIZE // INODE_SIZE
+        block_no = self._bgd_inode_table_block(group) + (local_index // inodes_per_block)
+        block_offset = (local_index % inodes_per_block) * INODE_SIZE
+        raw = self._read_block(block_no)[block_offset:block_offset + INODE_SIZE]
+
+        mode = struct.unpack_from("<H", raw, 0)[0]
+        uid = struct.unpack_from("<H", raw, 2)[0]
+        size_lo = struct.unpack_from("<I", raw, 4)[0]
+        atime = struct.unpack_from("<I", raw, 8)[0]
+        ctime = struct.unpack_from("<I", raw, 12)[0]
+        mtime = struct.unpack_from("<I", raw, 16)[0]
+        gid = struct.unpack_from("<H", raw, 24)[0]
+        links_count = struct.unpack_from("<H", raw, 26)[0]
+        blocks_lo = struct.unpack_from("<I", raw, 28)[0]
+        block = struct.unpack_from("<15I", raw, 40)
+        size_hi = struct.unpack_from("<I", raw, 108)[0]
+
+        return Inode(
+            mode=mode,
+            uid=uid,
+            gid=gid,
+            size_lo=size_lo,
+            size_hi=size_hi,
+            atime=atime,
+            ctime=ctime,
+            mtime=mtime,
+            links_count=links_count,
+            blocks_lo=blocks_lo,
+            block=block,
+        )
+
+    def inode_block(self, inode: Inode, block_index: int) -> int:
+        if block_index < N_DIRECT_BLOCKS:
+            return inode.block[block_index]
+
+        pointers_per_block = BLOCK_SIZE // 4
+        block_index -= N_DIRECT_BLOCKS
+
+        if block_index < pointers_per_block:
+            indirect_block = inode.block[12]
+            if indirect_block == 0:
+                return 0
+            indirect = self._read_block(indirect_block)
+            return struct.unpack_from("<I", indirect, block_index * 4)[0]
+
+        block_index -= pointers_per_block
+        if block_index < pointers_per_block * pointers_per_block:
+            level1_block = inode.block[13]
+            if level1_block == 0:
+                return 0
+            level1 = self._read_block(level1_block)
+            level1_index = block_index // pointers_per_block
+            level2_index = block_index % pointers_per_block
+            level2_block = struct.unpack_from("<I", level1, level1_index * 4)[0]
+            if level2_block == 0:
+                return 0
+            level2 = self._read_block(level2_block)
+            return struct.unpack_from("<I", level2, level2_index * 4)[0]
+
+        return 0
+
+    def read_file(self, inode: Inode) -> bytes:
+        remaining = inode.size
+        if remaining == 0:
+            return b""
+
+        chunks = []
+        block_index = 0
+        while remaining > 0:
+            block_no = self.inode_block(inode, block_index)
+            if block_no == 0:
+                break
+            block = self._read_block(block_no)
+            chunk = min(remaining, BLOCK_SIZE)
+            chunks.append(block[:chunk])
+            remaining -= chunk
+            block_index += 1
+
+        data = b"".join(chunks)
+        if len(data) != inode.size:
+            raise ValueError(f"inode read was truncated: expected {inode.size} bytes, got {len(data)}")
+        return data
+
+    def iter_dir(self, inode: Inode):
+        if (inode.mode & IFMT) != IFDIR:
+            raise NotADirectoryError("inode is not a directory")
+
+        cursor = 0
+        while cursor < inode.size:
+            logical_block = cursor // BLOCK_SIZE
+            block_offset = cursor % BLOCK_SIZE
+            block_no = self.inode_block(inode, logical_block)
+            if block_no == 0:
+                break
+            block = self._read_block(block_no)
+            advanced = False
+
+            while block_offset + 8 <= BLOCK_SIZE and cursor < inode.size:
+                inode_no = struct.unpack_from("<I", block, block_offset)[0]
+                rec_len = struct.unpack_from("<H", block, block_offset + 4)[0]
+                name_len = block[block_offset + 6]
+                if rec_len < 8:
+                    break
+
+                if inode_no != 0 and name_len > 0:
+                    name_bytes = block[block_offset + 8:block_offset + 8 + name_len]
+                    name = name_bytes.decode("utf-8", errors="surrogateescape")
+                    if name not in (".", ".."):
+                        yield name, inode_no
+
+                block_offset += rec_len
+                cursor += rec_len
+                advanced = True
+
+            if not advanced:
+                cursor += BLOCK_SIZE
+
+    def lookup_path(self, source_path: str) -> tuple[int, Inode]:
+        if not source_path.startswith("/"):
+            raise ValueError(f"path must be absolute: {source_path}")
+
+        current_ino = ROOT_INO
+        current_inode = self.read_inode(current_ino)
+        if source_path == "/":
+            return current_ino, current_inode
+
+        for component in [part for part in source_path.split("/") if part]:
+            if (current_inode.mode & IFMT) != IFDIR:
+                raise NotADirectoryError(f"{component} is not inside a directory")
+
+            next_ino = None
+            for name, inode_no in self.iter_dir(current_inode):
+                if name == component:
+                    next_ino = inode_no
+                    break
+            if next_ino is None:
+                raise FileNotFoundError(f"{source_path} not found in {self.image_path}")
+            current_ino = next_ino
+            current_inode = self.read_inode(current_ino)
+
+        return current_ino, current_inode
+
+
+def apply_metadata(dest: Path, inode: Inode, *, follow_symlinks: bool) -> None:
+    mode = inode.mode & 0o7777
+    os.chmod(dest, mode, follow_symlinks=follow_symlinks)
+    os.utime(dest, (inode.atime, inode.mtime), follow_symlinks=follow_symlinks)
+
+
+def safe_child_path(dest: Path, name: str) -> Path:
+    if not name or name in (".", "..") or "/" in name or "\\" in name:
+        raise ValueError(f"unsafe directory entry name: {name!r}")
+    if os.path.sep and os.path.sep in name:
+        raise ValueError(f"unsafe directory entry name: {name!r}")
+    if os.path.altsep and os.path.altsep in name:
+        raise ValueError(f"unsafe directory entry name: {name!r}")
+    return dest / name
+
+
+def extract_inode(image: BlueyFSImage, inode_no: int, dest: Path) -> None:
+    inode = image.read_inode(inode_no)
+    inode_type = inode.mode & IFMT
+
+    if inode_type == IFDIR:
+        dest.mkdir(parents=True, exist_ok=True)
+        for name, child_ino in image.iter_dir(inode):
+            extract_inode(image, child_ino, safe_child_path(dest, name))
+        apply_metadata(dest, inode, follow_symlinks=False)
+        return
+
+    if inode_type == IFREG:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(image.read_file(inode))
+        apply_metadata(dest, inode, follow_symlinks=True)
+        return
+
+    if inode_type == IFLNK:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        target = image.read_file(inode).decode("utf-8", errors="surrogateescape").rstrip("\x00")
+        if dest.exists() or dest.is_symlink():
+            dest.unlink()
+        os.symlink(target, dest)
+        return
+
+    raise ValueError(f"unsupported inode type 0x{inode_type:04x} for {dest}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Extract /var/log from a BlueyOS disk image")
+    parser.add_argument("--image", default="build/blueyos-disk.img", help="disk image to inspect")
+    parser.add_argument("--source-path", default="/var/log", help="absolute BlueyFS path to extract")
+    parser.add_argument("--output-dir", default="debug/var-log", help="host directory to populate")
+    parser.add_argument("--start-sector", type=int, help="BlueyFS start sector (defaults to MBR root partition)")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    image_path = Path(args.image)
+    output_dir = Path(args.output_dir)
+
+    if not image_path.is_file():
+        print(f"error: image not found: {image_path}", file=sys.stderr)
+        return 1
+
+    if output_dir.exists():
+        if not output_dir.is_dir():
+            print(f"error: output path exists and is not a directory: {output_dir}", file=sys.stderr)
+            return 1
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    image = BlueyFSImage(image_path, args.start_sector)
+    try:
+        _, source_inode = image.lookup_path(args.source_path)
+        if (source_inode.mode & IFMT) != IFDIR:
+            print(f"error: source path is not a directory: {args.source_path}", file=sys.stderr)
+            return 1
+
+        for name, inode_no in image.iter_dir(source_inode):
+            extract_inode(image, inode_no, safe_child_path(output_dir, name))
+    except (FileNotFoundError, NotADirectoryError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        image.close()
+
+    print(f"Extracted {args.source_path} from {image_path} (start sector {image.start_sector}) to {output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
This pull request introduces several improvements and additions to the BlueyOS kernel (`biscuits`), with a primary focus on completing the networking control plane (`netctl`) and enhancing developer documentation and build tooling. The most significant change is the full implementation of address and route management in the kernel's Netlink-inspired networking stack. Additional updates include new developer documentation, minor improvements to the build system, and documentation clarifications for related ecosystem projects.

**Networking stack (kernel):**

* Fully implemented handlers for address and route management in `kernel/netctl.c`, including `ADDR_NEW`, `ADDR_DEL`, `ADDR_LIST`, `ROUTE_NEW`, `ROUTE_DEL`, and `ROUTE_LIST` requests. This enables userspace tools to add, delete, and list IP addresses and routes via the `netctl` socket. [[1]](diffhunk://#diff-c9045bdfdecdf385d21429ae4f69cd0013d4c9474ff14ca60e26bcac871f35f6R375-R739) [[2]](diffhunk://#diff-c9045bdfdecdf385d21429ae4f69cd0013d4c9474ff14ca60e26bcac871f35f6R782-R797)

**Developer documentation:**

* Added `.github/copilot-instructions.md` with a comprehensive quick-reference for Copilot/AI agents, project overview, networking stack details, related repositories, conventions, and build/test instructions.
* Updated `AGENT_INSTRUCTIONS.md` to clarify the roles of `walkies` and `scout`, and added guidance for working on the DHCP/DNS client and its coordination with the kernel networking stack. [[1]](diffhunk://#diff-24aa3ce64692de719eb74dafc14a3d337e50c86d8b3f49ea2f21750c5f22e21aL19-R20) [[2]](diffhunk://#diff-24aa3ce64692de719eb74dafc14a3d337e50c86d8b3f49ea2f21750c5f22e21aR29-R30)

**Build system and tooling:**

* Added a new `extract-var-log` Makefile target to extract `/var/log` from the disk image for debugging, and documented this in the help output. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L388-R388) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R436-R438) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R554)

**Boot configuration:**

* Updated `grub.cfg` to pass `verbose=2` to the kernel by default, enabling debug-level logging on boot.