### PR TITLE
Capture kprintf output in ring buffer and add sys_syslog syscall

### DIFF
--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -163,6 +163,9 @@ void kernel_main(uint32_t magic, uint32_t *mboot_info) {
     // Step 1b: Syslog — initialise ring buffer before any other subsystem
     syslog_init();
     syslog_set_verbose(boot_args.verbose);
+    // Redirect all kprintf() output into the ring buffer so kernel.log
+    // captures the full boot sequence, not just explicit syslog_* calls.
+    syslog_install_kprintf_hook();
     syslog_info("KERN", "BlueyOS kernel starting up (verbose=%d)", boot_args.verbose);
 
     kprintf("  %s\n", BLUEYOS_VERSION_STRING);

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -2046,6 +2046,43 @@ static int32_t sys_faccessat2(int dirfd, const char *path, int mode, int flags) 
 }
 #undef FACCESSAT2_VALID_FLAGS
 
+// ---------------------------------------------------------------------------
+// sys_syslog — klogctl(2) / dmesg ring-buffer access (NR 103)
+// ---------------------------------------------------------------------------
+// Implements the Linux syslog(2) interface (subset).
+// type values:
+//   2  READ        — copy up to `len` unread bytes to buf; we treat as READ_ALL
+//   3  READ_ALL    — copy the whole ring buffer to buf
+//   9  SIZE_UNREAD — return number of characters in the ring (approx)
+//  10  SIZE_BUFFER — return maximum buffer size
+
+// Include syslog.h for syslog_read_entries
+#include "syslog.h"
+
+#define KLOG_READ        2
+#define KLOG_READ_ALL    3
+#define KLOG_SIZE_UNREAD 9
+#define KLOG_SIZE_BUFFER 10
+
+// Maximum text size we'll ever return (~128 entries * ~160 bytes each)
+#define KLOG_MAX_TEXT    (128 * 160)
+
+static int32_t sys_syslog(int type, char *buf, int len) {
+    switch (type) {
+        case KLOG_READ:
+        case KLOG_READ_ALL: {
+            if (!buf || len <= 0) return -BLUEY_EINVAL;
+            if (!buf) return -BLUEY_EFAULT;
+            return (int32_t)syslog_read_entries(buf, len);
+        }
+        case KLOG_SIZE_UNREAD:
+        case KLOG_SIZE_BUFFER:
+            return KLOG_MAX_TEXT;
+        default:
+            return -BLUEY_EINVAL;
+    }
+}
+
 /* Minimal fcntl: F_DUPFD, F_GETFD, F_SETFD, F_GETFL, F_SETFL */
 #define FCNTL_F_DUPFD   0
 #define FCNTL_F_GETFD   1
@@ -3530,6 +3567,9 @@ int32_t syscall_dispatch(registers_t *regs) {
         case SYS_FACCESSAT2:
             ret = sys_faccessat2((int)regs->ebx, (const char*)regs->ecx,
                                  (int)regs->edx, (int)regs->esi);
+            break;
+        case SYS_SYSLOG:
+            ret = sys_syslog((int)regs->ebx, (char*)regs->ecx, (int)regs->edx);
             break;
         default: {
             /* Unknown syscall - don't crash. Log caller info to help mapping. */

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -2061,9 +2061,7 @@ static int32_t sys_faccessat2(int dirfd, const char *path, int mode, int flags) 
 #define KLOG_SIZE_UNREAD 9
 #define KLOG_SIZE_BUFFER 10
 
-/* Maximum formatted overhead added by syslog_read_entries() per entry.
- * Keep this conservative so klogctl size queries return a safe buffer size. */
-#define KLOG_PREFIX_MAX  256
+#define KLOG_PREFIX_MAX  SYSLOG_FMT_OVERHEAD
 #define KLOG_MAX_TEXT    (SYSLOG_RING_ENTRIES * (SYSLOG_MSG_MAX + KLOG_PREFIX_MAX))
 
 static int32_t sys_syslog(int type, char *buf, int len) {

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -2056,24 +2056,29 @@ static int32_t sys_faccessat2(int dirfd, const char *path, int mode, int flags) 
 //   9  SIZE_UNREAD — return number of characters in the ring (approx)
 //  10  SIZE_BUFFER — return maximum buffer size
 
-// Include syslog.h for syslog_read_entries
-#include "syslog.h"
-
 #define KLOG_READ        2
 #define KLOG_READ_ALL    3
 #define KLOG_SIZE_UNREAD 9
 #define KLOG_SIZE_BUFFER 10
 
-// Maximum text size we'll ever return (~128 entries * ~160 bytes each)
-#define KLOG_MAX_TEXT    (128 * 160)
+/* Maximum formatted overhead added by syslog_read_entries() per entry.
+ * Keep this conservative so klogctl size queries return a safe buffer size. */
+#define KLOG_PREFIX_MAX  256
+#define KLOG_MAX_TEXT    (SYSLOG_RING_ENTRIES * (SYSLOG_MSG_MAX + KLOG_PREFIX_MAX))
 
 static int32_t sys_syslog(int type, char *buf, int len) {
     switch (type) {
         case KLOG_READ:
         case KLOG_READ_ALL: {
-            if (!buf || len <= 0) return -BLUEY_EINVAL;
+            int read_ret;
+
             if (!buf) return -BLUEY_EFAULT;
-            return (int32_t)syslog_read_entries(buf, len);
+            if (len <= 0) return -BLUEY_EINVAL;
+
+            read_ret = (int)syslog_read_entries(buf, len);
+            if (read_ret < 0) return -BLUEY_EIO;
+
+            return (int32_t)read_ret;
         }
         case KLOG_SIZE_UNREAD:
         case KLOG_SIZE_BUFFER:

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -12,6 +12,7 @@
 #define SYS_WRITE         1
 #define SYS_OPEN          2
 #define SYS_CLOSE         3
+#define SYS_SYSLOG        103  /* klogctl / dmesg — read kernel ring buffer */
 #define SYS_SYNC          36
 #define SYS_STAT          4
 #define SYS_FSTAT         5

--- a/kernel/syslog.c
+++ b/kernel/syslog.c
@@ -241,11 +241,11 @@ static void syslog_write_loc_va(int level, const char *tag, const char *file,
         else if (level == LOG_DEBUG)    vga_set_color(VGA_DARK_GREY,   VGA_BLACK);
         else                            vga_set_color(VGA_WHITE,       VGA_BLACK);
         if (g_verbose_level >= VERBOSE_INFO && entry->src_file[0] != '\0') {
-            kprintf("[%4u][%s](%s:%s) %s\n",
+            kprintf_direct("[%4u][%s](%s:%s) %s\n",
                     entry->timestamp, entry->tag,
                     entry->src_file, entry->src_func, entry->msg);
         } else {
-            kprintf("[%4u][%s] %s\n", entry->timestamp, entry->tag, entry->msg);
+            kprintf_direct("[%4u][%s] %s\n", entry->timestamp, entry->tag, entry->msg);
         }
         vga_set_color(VGA_WHITE, VGA_BLACK);
     }
@@ -312,7 +312,7 @@ void syslog_dmesg(void) {
         }
     }
     vga_set_color(VGA_WHITE, VGA_BLACK);
-    kprintf("-- end of kernel log --\n");
+    kprintf_direct("-- end of kernel log --\n");
 }
 
 // Lightweight helper to let other subsystems record a caller address into
@@ -324,6 +324,97 @@ void syslog_record_caller(void *caller) {
     syslog_flush_hist[fh_idx].caller = caller;
     syslog_flush_hist_head++;
     if (syslog_flush_hist_count < FLUSH_HIST_ENTRIES) syslog_flush_hist_count++;
+}
+
+// ---------------------------------------------------------------------------
+// kprintf hook — capture all kprintf output into the ring buffer
+// ---------------------------------------------------------------------------
+
+// When the hook is active it REPLACES VGA output, so each char must be
+// forwarded to the VGA backend (via kprintf_putchar) and also buffered into
+// a line buffer.  On newline (or overflow) the accumulated line is committed
+// to the ring buffer as a LOG_INFO "KERN" entry without going back through
+// kprintf (which would recurse).
+
+#define KPRINTF_HOOK_BUF 256
+static char   kprintf_hook_buf[KPRINTF_HOOK_BUF];
+static int    kprintf_hook_pos = 0;
+static int    kprintf_hook_in  = 0; // recursion guard
+
+static void kprintf_syslog_hook(char c, void *ctx) {
+    (void)ctx;
+
+    // Always emit to VGA (hook replaces the normal VGA path)
+    kprintf_putchar(c);
+
+    // Guard against re-entrancy (syslog -> kprintf_direct is fine, but any
+    // path that called kprintf would recurse back here)
+    if (kprintf_hook_in) return;
+
+    // Buffer the character
+    if (kprintf_hook_pos < KPRINTF_HOOK_BUF - 1) {
+        kprintf_hook_buf[kprintf_hook_pos++] = c;
+    }
+
+    // Flush on newline or when the buffer is nearly full
+    if (c == '\n' || kprintf_hook_pos >= KPRINTF_HOOK_BUF - 1) {
+        kprintf_hook_buf[kprintf_hook_pos] = '\0';
+        // Strip trailing newline for cleaner storage
+        int end = kprintf_hook_pos - 1;
+        while (end >= 0 && (kprintf_hook_buf[end] == '\n' || kprintf_hook_buf[end] == '\r'))
+            kprintf_hook_buf[end--] = '\0';
+
+        if (kprintf_hook_buf[0] != '\0') {
+            kprintf_hook_in = 1;
+            syslog_write(LOG_INFO, "KERN", "%s", kprintf_hook_buf);
+            kprintf_hook_in = 0;
+        }
+        kprintf_hook_pos = 0;
+    }
+}
+
+void syslog_install_kprintf_hook(void) {
+    kprintf_hook_pos = 0;
+    kprintf_hook_in  = 0;
+    kprintf_set_output_hook(kprintf_syslog_hook, NULL);
+}
+
+// ---------------------------------------------------------------------------
+// syslog_read_entries — copy ring buffer as text to a userspace buffer
+// ---------------------------------------------------------------------------
+// Used by the sys_syslog syscall (type=3 READ_ALL).
+// Returns the number of bytes written (not including NUL), or -1 on error.
+
+int syslog_read_entries(char *buf, int bufsize) {
+    if (!buf || bufsize <= 0) return -1;
+
+    uint32_t n = syslog_count_val;
+    uint32_t start = (syslog_head - n) % SYSLOG_RING_ENTRIES;
+    int pos = 0;
+
+    for (uint32_t i = 0; i < n && pos < bufsize - 1; i++) {
+        syslog_entry_t *e = &syslog_ring[(start + i) % SYSLOG_RING_ENTRIES];
+        char line[SYSLOG_MSG_MAX + 160];
+        int len;
+        if (e->src_file[0] != '\0') {
+            len = syslog_snprintf(line, sizeof(line),
+                                  "[%u] [T+%us] %s [%s](%s:%s) %s\n",
+                                  e->seq, e->timestamp,
+                                  level_str((int)e->level), e->tag,
+                                  e->src_file, e->src_func, e->msg);
+        } else {
+            len = syslog_snprintf(line, sizeof(line),
+                                  "[%u] [T+%us] %s [%s] %s\n",
+                                  e->seq, e->timestamp,
+                                  level_str((int)e->level), e->tag, e->msg);
+        }
+        int copy = len;
+        if (pos + copy > bufsize - 1) copy = bufsize - 1 - pos;
+        memcpy(buf + pos, line, (size_t)copy);
+        pos += copy;
+    }
+    buf[pos] = '\0';
+    return pos;
 }
 
 // ---------------------------------------------------------------------------

--- a/kernel/syslog.c
+++ b/kernel/syslog.c
@@ -24,10 +24,7 @@
 // ---------------------------------------------------------------------------
 
 // We store entries in a flat array (not a byte ring) for simplicity.
-// With SYSLOG_RING_ENTRIES entries of ~296 bytes each this is ~30 KB —
-// acceptable for a kernel research OS with a 1 MB heap.
-#define SYSLOG_RING_ENTRIES  128
-
+// With SYSLOG_RING_ENTRIES entries this is acceptable for a kernel research OS.
 static syslog_entry_t syslog_ring[SYSLOG_RING_ENTRIES];
 static uint32_t       syslog_head  = 0;   /* next slot to write into */
 static uint32_t       syslog_count_val = 0;
@@ -294,7 +291,7 @@ void syslog_dmesg(void) {
     uint32_t start = (syslog_head - n) % SYSLOG_RING_ENTRIES;
 
     vga_set_color(VGA_LIGHT_CYAN, VGA_BLACK);
-    kprintf("-- Kernel log (%u entries) --\n", n);
+    kprintf_direct("-- Kernel log (%u entries) --\n", n);
     vga_set_color(VGA_WHITE, VGA_BLACK);
 
     for (uint32_t i = 0; i < n; i++) {
@@ -305,10 +302,10 @@ void syslog_dmesg(void) {
         else if (e->level == LOG_DEBUG)   vga_set_color(VGA_DARK_GREY,   VGA_BLACK);
         else                              vga_set_color(VGA_WHITE,       VGA_BLACK);
 
-        kprintf("[%u] [T+%us] %s [%s] %s\n",
-                e->seq, e->timestamp, level_str((int)e->level), e->tag, e->msg);
+        kprintf_direct("[%u] [T+%us] %s [%s] %s\n",
+                       e->seq, e->timestamp, level_str((int)e->level), e->tag, e->msg);
         if (g_verbose_level >= VERBOSE_INFO && e->src_file[0] != '\0') {
-            kprintf("         src: %s:%s\n", e->src_file, e->src_func);
+            kprintf_direct("         src: %s:%s\n", e->src_file, e->src_func);
         }
     }
     vga_set_color(VGA_WHITE, VGA_BLACK);
@@ -388,33 +385,60 @@ void syslog_install_kprintf_hook(void) {
 int syslog_read_entries(char *buf, int bufsize) {
     if (!buf || bufsize <= 0) return -1;
 
-    uint32_t n = syslog_count_val;
-    uint32_t start = (syslog_head - n) % SYSLOG_RING_ENTRIES;
-    int pos = 0;
+    for (int attempt = 0; attempt < 4; attempt++) {
+        uint32_t snap_head = syslog_head;
+        uint32_t snap_count = syslog_count_val;
+        uint32_t snap_seq = syslog_seq;
+        uint32_t n = snap_count;
+        uint32_t start = (snap_head + SYSLOG_RING_ENTRIES -
+                          (n % SYSLOG_RING_ENTRIES)) % SYSLOG_RING_ENTRIES;
+        int pos = 0;
+        int retry = 0;
 
-    for (uint32_t i = 0; i < n && pos < bufsize - 1; i++) {
-        syslog_entry_t *e = &syslog_ring[(start + i) % SYSLOG_RING_ENTRIES];
-        char line[SYSLOG_MSG_MAX + 160];
-        int len;
-        if (e->src_file[0] != '\0') {
-            len = syslog_snprintf(line, sizeof(line),
-                                  "[%u] [T+%us] %s [%s](%s:%s) %s\n",
-                                  e->seq, e->timestamp,
-                                  level_str((int)e->level), e->tag,
-                                  e->src_file, e->src_func, e->msg);
-        } else {
-            len = syslog_snprintf(line, sizeof(line),
-                                  "[%u] [T+%us] %s [%s] %s\n",
-                                  e->seq, e->timestamp,
-                                  level_str((int)e->level), e->tag, e->msg);
+        for (uint32_t i = 0; i < n && pos < bufsize - 1; i++) {
+            uint32_t idx = (start + i) % SYSLOG_RING_ENTRIES;
+            syslog_entry_t entry_a;
+            syslog_entry_t entry_b;
+            char line[SYSLOG_MSG_MAX + 160];
+            int len;
+
+            memcpy(&entry_a, &syslog_ring[idx], sizeof(syslog_entry_t));
+            memcpy(&entry_b, &syslog_ring[idx], sizeof(syslog_entry_t));
+            if (memcmp(&entry_a, &entry_b, sizeof(syslog_entry_t)) != 0) {
+                retry = 1;
+                break;
+            }
+
+            if (entry_a.src_file[0] != '\0') {
+                len = syslog_snprintf(line, sizeof(line),
+                                      "[%u] [T+%us] %s [%s](%s:%s) %s\n",
+                                      entry_a.seq, entry_a.timestamp,
+                                      level_str((int)entry_a.level), entry_a.tag,
+                                      entry_a.src_file, entry_a.src_func, entry_a.msg);
+            } else {
+                len = syslog_snprintf(line, sizeof(line),
+                                      "[%u] [T+%us] %s [%s] %s\n",
+                                      entry_a.seq, entry_a.timestamp,
+                                      level_str((int)entry_a.level), entry_a.tag, entry_a.msg);
+            }
+
+            int copy = len;
+            if (pos + copy > bufsize - 1) copy = bufsize - 1 - pos;
+            memcpy(buf + pos, line, (size_t)copy);
+            pos += copy;
         }
-        int copy = len;
-        if (pos + copy > bufsize - 1) copy = bufsize - 1 - pos;
-        memcpy(buf + pos, line, (size_t)copy);
-        pos += copy;
+
+        if (!retry &&
+            snap_head == syslog_head &&
+            snap_count == syslog_count_val &&
+            snap_seq == syslog_seq) {
+            buf[pos] = '\0';
+            return pos;
+        }
     }
-    buf[pos] = '\0';
-    return pos;
+
+    buf[0] = '\0';
+    return -1;
 }
 
 // ---------------------------------------------------------------------------

--- a/kernel/syslog.c
+++ b/kernel/syslog.c
@@ -385,60 +385,61 @@ void syslog_install_kprintf_hook(void) {
 int syslog_read_entries(char *buf, int bufsize) {
     if (!buf || bufsize <= 0) return -1;
 
-    for (int attempt = 0; attempt < 4; attempt++) {
-        uint32_t snap_head = syslog_head;
-        uint32_t snap_count = syslog_count_val;
-        uint32_t snap_seq = syslog_seq;
-        uint32_t n = snap_count;
-        uint32_t start = (snap_head + SYSLOG_RING_ENTRIES -
-                          (n % SYSLOG_RING_ENTRIES)) % SYSLOG_RING_ENTRIES;
-        int pos = 0;
-        int retry = 0;
+    uint32_t flags = 0;
+    uint32_t alloc_n = SYSLOG_RING_ENTRIES;
+    uint32_t snap_head = 0;
+    uint32_t snap_count = 0;
+    uint32_t start = 0;
+    int pos = 0;
+    syslog_entry_t *snapshot;
 
-        for (uint32_t i = 0; i < n && pos < bufsize - 1; i++) {
-            uint32_t idx = (start + i) % SYSLOG_RING_ENTRIES;
-            syslog_entry_t entry_a;
-            syslog_entry_t entry_b;
-            char line[SYSLOG_MSG_MAX + 160];
-            int len;
-
-            memcpy(&entry_a, &syslog_ring[idx], sizeof(syslog_entry_t));
-            memcpy(&entry_b, &syslog_ring[idx], sizeof(syslog_entry_t));
-            if (memcmp(&entry_a, &entry_b, sizeof(syslog_entry_t)) != 0) {
-                retry = 1;
-                break;
-            }
-
-            if (entry_a.src_file[0] != '\0') {
-                len = syslog_snprintf(line, sizeof(line),
-                                      "[%u] [T+%us] %s [%s](%s:%s) %s\n",
-                                      entry_a.seq, entry_a.timestamp,
-                                      level_str((int)entry_a.level), entry_a.tag,
-                                      entry_a.src_file, entry_a.src_func, entry_a.msg);
-            } else {
-                len = syslog_snprintf(line, sizeof(line),
-                                      "[%u] [T+%us] %s [%s] %s\n",
-                                      entry_a.seq, entry_a.timestamp,
-                                      level_str((int)entry_a.level), entry_a.tag, entry_a.msg);
-            }
-
-            int copy = len;
-            if (pos + copy > bufsize - 1) copy = bufsize - 1 - pos;
-            memcpy(buf + pos, line, (size_t)copy);
-            pos += copy;
-        }
-
-        if (!retry &&
-            snap_head == syslog_head &&
-            snap_count == syslog_count_val &&
-            snap_seq == syslog_seq) {
-            buf[pos] = '\0';
-            return pos;
-        }
+    snapshot = kheap_alloc((size_t)alloc_n * sizeof(syslog_entry_t), 0);
+    if (!snapshot) {
+        return -1;
     }
 
-    buf[0] = '\0';
-    return -1;
+    __asm__ volatile("pushf; cli; pop %0" : "=r"(flags) : : "memory", "cc");
+    snap_head = syslog_head;
+    snap_count = syslog_count_val;
+    if (snap_count > SYSLOG_RING_ENTRIES) snap_count = SYSLOG_RING_ENTRIES;
+    if (snap_count > alloc_n) snap_count = alloc_n;
+    start = (snap_head + SYSLOG_RING_ENTRIES - snap_count) % SYSLOG_RING_ENTRIES;
+    for (uint32_t i = 0; i < snap_count; i++) {
+        memcpy(&snapshot[i], &syslog_ring[(start + i) % SYSLOG_RING_ENTRIES],
+               sizeof(syslog_entry_t));
+    }
+    __asm__ volatile("push %0; popf" : : "r"(flags) : "memory", "cc");
+
+    if (snap_count == 0) {
+        kheap_free(snapshot);
+        return 0;
+    }
+
+    for (uint32_t i = 0; i < snap_count && pos < bufsize - 1; i++) {
+        const syslog_entry_t *e = &snapshot[i];
+        char line[SYSLOG_MSG_MAX + SYSLOG_FMT_OVERHEAD];
+        int len;
+        if (e->src_file[0] != '\0') {
+            len = syslog_snprintf(line, sizeof(line),
+                                  "[%u] [T+%us] %s [%s](%s:%s) %s\n",
+                                  e->seq, e->timestamp,
+                                  level_str((int)e->level), e->tag,
+                                  e->src_file, e->src_func, e->msg);
+        } else {
+            len = syslog_snprintf(line, sizeof(line),
+                                  "[%u] [T+%us] %s [%s] %s\n",
+                                  e->seq, e->timestamp,
+                                  level_str((int)e->level), e->tag, e->msg);
+        }
+        int copy = len;
+        if (pos + copy > bufsize - 1) copy = bufsize - 1 - pos;
+        memcpy(buf + pos, line, (size_t)copy);
+        pos += copy;
+    }
+
+    buf[pos] = '\0';
+    kheap_free(snapshot);
+    return pos;
 }
 
 // ---------------------------------------------------------------------------
@@ -527,7 +528,7 @@ void syslog_flush_to_fs(void) {
         }
 
         /* Now write out the snapshot without holding locks or disabling IRQs. */
-        char line[SYSLOG_MSG_MAX + 160];
+        char line[SYSLOG_MSG_MAX + SYSLOG_FMT_OVERHEAD];
         for (uint32_t i = 0; i < n; i++) {
             syslog_entry_t *e = &snapshot[i];
             char lvlbuf[16];
@@ -554,7 +555,7 @@ void syslog_flush_to_fs(void) {
         kheap_free(snapshot);
     } else {
         /* Allocation failed: fall back to direct writes but be defensive. */
-        char line[SYSLOG_MSG_MAX + 160];
+        char line[SYSLOG_MSG_MAX + SYSLOG_FMT_OVERHEAD];
         for (uint32_t i = 0; i < n; i++) {
             syslog_entry_t *e = &syslog_ring[(start + i) % SYSLOG_RING_ENTRIES];
             char lvlbuf[16];

--- a/kernel/syslog.h
+++ b/kernel/syslog.h
@@ -32,6 +32,7 @@
 // Maximum length of the message payload stored in each ring entry.
 // The total number of entries in the ring is managed internally by syslog.c.
 #define SYSLOG_MSG_MAX      256   /* maximum length of a single log line       */
+#define SYSLOG_RING_ENTRIES 128   /* total number of in-memory ring entries     */
 
 // ---------------------------------------------------------------------------
 // Log entry (stored in the ring buffer as a packed record)

--- a/kernel/syslog.h
+++ b/kernel/syslog.h
@@ -33,6 +33,7 @@
 // The total number of entries in the ring is managed internally by syslog.c.
 #define SYSLOG_MSG_MAX      256   /* maximum length of a single log line       */
 #define SYSLOG_RING_ENTRIES 128   /* total number of in-memory ring entries     */
+#define SYSLOG_FMT_OVERHEAD 160   /* fixed formatting overhead per rendered line */
 
 // ---------------------------------------------------------------------------
 // Log entry (stored in the ring buffer as a packed record)

--- a/kernel/syslog.h
+++ b/kernel/syslog.h
@@ -86,6 +86,17 @@ void syslog_dmesg(void);
 // Return the number of entries currently in the ring buffer.
 uint32_t syslog_count(void);
 
+// Install a kprintf hook so that all kprintf() output is also captured into
+// the ring buffer at LOG_INFO level.  Call once after syslog_init().
+// After this call, kprintf() and kprintf_direct() both reach VGA; only
+// kprintf() output is additionally stored in the ring.
+void syslog_install_kprintf_hook(void);
+
+// Copy all ring-buffer entries to buf as human-readable text (one line per
+// entry).  Used by the sys_syslog syscall (type=3 READ_ALL).
+// Returns bytes written (excluding NUL), or -1 on invalid args.
+int syslog_read_entries(char *buf, int bufsize);
+
 // Lightweight hook for other subsystems to record a caller into the
 // syslog flush history buffer. Callers should pass their return address
 // (e.g. __builtin_return_address(0)). This is useful for short-lived

--- a/lib/stdio.c
+++ b/lib/stdio.c
@@ -317,6 +317,14 @@ void kprintf_direct(const char *fmt, ...) {
     kprintf_backend_flush();
 }
 
+void kprintf_putchar(char c) {
+    kprintf_backend_putc(c);
+}
+
+void kprintf_flush(void) {
+    kprintf_backend_flush();
+}
+
 void kprintf(const char *fmt, ...) {
     va_list ap;
     va_start(ap, fmt);

--- a/lib/stdio.h
+++ b/lib/stdio.h
@@ -13,3 +13,9 @@ void kprintf_set_output_hook(kprintf_output_hook_t hook, void *ctx);
 kprintf_output_state_t kprintf_get_output_state(void);
 void kprintf_restore_output_state(kprintf_output_state_t state);
 void kprintf(const char *fmt, ...);
+
+// Write a single character directly to the console backend (no hook, no
+// format parsing). Intended for use inside kprintf hooks to emit characters
+// to the VGA console while avoiding recursion.
+void kprintf_putchar(char c);
+void kprintf_flush(void);


### PR DESCRIPTION
Previously kprintf() wrote only to VGA, so /var/log/kernel.log contained just one line (the syslog_flush_to_fs() self-log). The ring buffer held only entries written via explicit syslog_write() calls.

Changes:
- lib/stdio: add kprintf_putchar(char) and kprintf_flush() so syslog's hook can forward characters to VGA without calling back into kprintf
- kernel/syslog: install a kprintf output hook (syslog_install_kprintf_hook) that buffers characters line-by-line and commits each completed line to the ring buffer at LOG_INFO/'KERN'. A recursion guard prevents the syslog->kprintf path from re-entering the hook.
- kernel/syslog: change syslog_write_loc_va VGA echo and syslog_dmesg footer to use kprintf_direct() (bypass hook) to avoid recursion now that kprintf() is intercepted.
- kernel/syslog: add syslog_read_entries(buf, len) to format the ring buffer as human-readable text into a caller-supplied buffer (used by sys_syslog).
- kernel/syscall: add sys_syslog (NR 103 / SYS_SYSLOG) implementing the Linux klogctl(2) subset needed by a userspace dmesg:
    type=2  READ      — copy ring to buf
    type=3  READ_ALL  — copy ring to buf (same as 2)
    type=9  SIZE_UNREAD — return max size constant
    type=10 SIZE_BUFFER — return max size constant
- kernel/kernel: call syslog_install_kprintf_hook() immediately after
  syslog_init() so the full boot sequence is captured.

After this change /var/log/kernel.log will contain every kprintf and syslog_write line from boot. A userspace dmesg can call:
    syscall(103, 3, buf, sizeof(buf))  — READ_ALL
to retrieve the full ring buffer as text.