### PR TITLE
Implement ESC[6n CPR response and enhance kernel ACPI handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,14 @@ user/init.elf
 qemu*.log
 qemu*.out
 qemu*.pid
+
+# Toolchain build artifacts (downloaded/extracted by baker build process)
+binutils-*/
+gcc-*/
+musl-*/
+glibc-*/
+build-gcc/
+build-binutils/
+*.tar.xz
+*.tar.bz2
+*.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,7 @@ I386_C_SOURCES = \
     kernel/scheduler.c \
     kernel/signal.c \
   kernel/syscall.c \
+  kernel/acpi.c \
   kernel/elf.c \
   kernel/sha256.c \
   kernel/password.c \

--- a/docs/DEFECT_ANALYSIS.md
+++ b/docs/DEFECT_ANALYSIS.md
@@ -18,6 +18,33 @@
 
 ## Kernel (nzmacgeek/biscuits)
 
+### K-12 🟢 procfs lacked monitoring files (uptime, meminfo, version, loadavg, per-pid, net/dev)
+**Status:** FIXED (this PR)
+
+The original procfs implementation only exposed `/proc/cmdline` (the boot kernel
+command line).  Userspace utilities such as `uptime`, `free`, `ps`, and network
+monitoring tools had no `/proc` files to read.
+
+**Fix applied:**
+- `/proc/uptime`       — seconds since boot (`.hundredths idle`) using `rtc_get_uptime_seconds()` + timer ticks.
+- `/proc/meminfo`      — Linux-compatible memory info: MemTotal (from multiboot RAM), MemFree / MemAvailable (kernel heap stats), plus BlueyOS-specific `KernelHeap*` fields.
+- `/proc/version`      — kernel version string including build host, user, number, date, time.
+- `/proc/loadavg`      — stub `0.00 0.00 0.00 1/N pid` (no load tracking implemented yet).
+- `/proc/<pid>/`       — per-process directory (state, uid/gid from `process_t`).
+- `/proc/<pid>/status` — Linux-compatible `Name`, `State`, `Pid`, `PPid`, `Uid`, `Gid`, `VmSize`, `VmRSS`, `Threads`.
+- `/proc/<pid>/cmdline`— process name as a NUL-terminated string (full argv not retained by kernel).
+- `/proc/self`         — alias for the current process's PID directory.
+- `/proc/net/dev`      — network interface counters from `netdev_device_t` (rx/tx bytes, packets, errors).
+- `stat()` and `readdir()` updated to expose all new paths and directories.
+
+**Known limitations:**
+- MemFree/MemAvailable reflects kernel heap free only; userspace process memory is not tracked.
+- VmSize/VmRSS is approximated from `brk` and user-stack extents; shared mappings not counted.
+- loadavg is always `0.00` (no load tracking).
+- `/proc/<pid>/cmdline` only contains the process name (argv not stored by kernel).
+
+---
+
 ### K-1 🔴 Heap initialised AFTER first module load
 **Status:** FIXED (this PR)
 

--- a/drivers/vt100.c
+++ b/drivers/vt100.c
@@ -12,6 +12,7 @@
 #include "vga.h"
 #include "vt100.h"
 #include "../kernel/tty.h"
+#include "../lib/stdio.h"
 
 // ---------------------------------------------------------------------------
 // State machine states
@@ -242,24 +243,31 @@ static void vt_handle_csi(char cmd) {
 
         case 'n':
             // ESC[6n — report cursor position as ESC[row;colR (1-based).
-            // Inject the response directly into the TTY input buffer so that
-            // userspace programs (bash readline) reading back the CPR reply
-            // don't block indefinitely.
+            // Only inject when ICANON is disabled (raw/readline mode).  When
+            // ICANON is active the terminal is in cooked login mode and injecting
+            // CPR bytes would corrupt the username read by matey.
             if (p0 == 6) {
-                char resp[16];
-                int pos = 0;
+                tty_termios_t cur_termios;
+                tty_get_termios(&cur_termios);
                 int row = vt_cur_row + 1;   /* 1-based */
                 int col = vt_cur_col + 1;   /* 1-based */
+                kprintf("[VT100] ESC[6n rcvd row=%d col=%d icanon=%d\n",
+                        row, col,
+                        (cur_termios.c_lflag & TTY_LFLAG_ICANON) ? 1 : 0);
+                if (!(cur_termios.c_lflag & TTY_LFLAG_ICANON)) {
+                    char resp[16];
+                    int pos = 0;
 
-                resp[pos++] = '\x1b';
-                resp[pos++] = '[';
-                if (row >= 10) resp[pos++] = '0' + (row / 10);
-                resp[pos++] = '0' + (row % 10);
-                resp[pos++] = ';';
-                if (col >= 10) resp[pos++] = '0' + (col / 10);
-                resp[pos++] = '0' + (col % 10);
-                resp[pos++] = 'R';
-                tty_inject_raw(resp, pos);
+                    resp[pos++] = '\x1b';
+                    resp[pos++] = '[';
+                    if (row >= 10) resp[pos++] = '0' + (row / 10);
+                    resp[pos++] = '0' + (row % 10);
+                    resp[pos++] = ';';
+                    if (col >= 10) resp[pos++] = '0' + (col / 10);
+                    resp[pos++] = '0' + (col % 10);
+                    resp[pos++] = 'R';
+                    tty_inject_raw(resp, pos);
+                }
             }
             break;
 

--- a/drivers/vt100.c
+++ b/drivers/vt100.c
@@ -11,6 +11,7 @@
 #include "../include/types.h"
 #include "vga.h"
 #include "vt100.h"
+#include "../kernel/tty.h"
 
 // ---------------------------------------------------------------------------
 // State machine states
@@ -240,9 +241,26 @@ static void vt_handle_csi(char cmd) {
         /* --- DSR — Device Status Report ------------------------------------ */
 
         case 'n':
-            // ESC [ 6 n — report cursor position as ESC [ row ; col R
-            // (We can't send characters back easily without a TTY;
-            //  this is a no-op stub for now.)
+            // ESC[6n — report cursor position as ESC[row;colR (1-based).
+            // Inject the response directly into the TTY input buffer so that
+            // userspace programs (bash readline) reading back the CPR reply
+            // don't block indefinitely.
+            if (p0 == 6) {
+                char resp[16];
+                int pos = 0;
+                int row = vt_cur_row + 1;   /* 1-based */
+                int col = vt_cur_col + 1;   /* 1-based */
+
+                resp[pos++] = '\x1b';
+                resp[pos++] = '[';
+                if (row >= 10) resp[pos++] = '0' + (row / 10);
+                resp[pos++] = '0' + (row % 10);
+                resp[pos++] = ';';
+                if (col >= 10) resp[pos++] = '0' + (col / 10);
+                resp[pos++] = '0' + (col % 10);
+                resp[pos++] = 'R';
+                tty_inject_raw(resp, pos);
+            }
             break;
 
         /* --- Scroll -------------------------------------------------------- */

--- a/fs/blueyfs.c
+++ b/fs/blueyfs.c
@@ -60,6 +60,7 @@ static uint32_t        jnl_start_blk = 0;  /* first block of journal region */
 #define BISCUITFS_MAX_OPEN  1024
 typedef struct {
     int      used;
+    int      refcount;   /* number of VFS fds (across all processes) sharing this slot */
     uint32_t inode_no;
     uint32_t offset;
     uint32_t size;
@@ -936,10 +937,13 @@ static int biscuitfs_open_cb(const char *path, int flags) {
             biscuitfs_inode_t inode;
             read_inode(ino, &inode);
             fd_table[i].used     = 1;
+            fd_table[i].refcount = 1;
             fd_table[i].inode_no = ino;
-            fd_table[i].offset   = 0;
             fd_table[i].size     = inode.size_lo;
             fd_table[i].flags    = (uint32_t)flags;
+            /* O_APPEND: start writing at end of file */
+            fd_table[i].offset   = (flags & VFS_O_APPEND) ? inode.size_lo : 0;
+            kprintf("[BISCUITFS] open slot=%d ino=%u size=%u flags=0x%x\n", i, ino, inode.size_lo, (unsigned)flags);
             if (flags & VFS_O_TRUNC) {
                 /* Would free data blocks and reset size; omitted for brevity */
                 fd_table[i].size = 0;
@@ -1019,10 +1023,8 @@ static int biscuitfs_read_at_cb(int fd, uint8_t *buf, size_t len, uint32_t offse
 
     if (!blkbuf) return -1;
 
-    if (biscuitfs_dbg_log_limited(&dbg_calls, 32)) {
-        kprintf("[BISCUITFS DBG] read_at enter fd=%d buf_ptr=%p len=%u offset=%u ino=%u size=%u fs_block_size=%u\n",
-                fd, buf, (unsigned)len, offset, f->inode_no, f->size, fs_block_size);
-    }
+    kprintf("[BISCUITFS] read_at slot=%d ino=%u offset=%u size=%u len=%u\n",
+            fd, f->inode_no, offset, f->size, (unsigned)len);
 
     if (offset >= f->size) {
         biscuitfs_free_block_buf(blkbuf);
@@ -1072,15 +1074,16 @@ static int biscuitfs_write_cb(int fd, const uint8_t *buf, size_t len) {
     if (fd < 0 || fd >= BISCUITFS_MAX_OPEN || !fd_table[fd].used) return -1;
     biscuitfs_fd_t *f = &fd_table[fd];
 
-#if BISCUITFS_DEBUG
-    /* Instrumentation: record which caller invoked BiscuitFS write. This
-     * helps correlate write attempts with syslog flush activity when
-     * tracking memory corruption sources. */
-    void *caller = __builtin_return_address(0);
-    syslog_record_caller(caller);
-    kprintf("[BISCUITFS DBG] write caller=%p fd=%d len=%u ino=%u\n",
-            caller, fd, (unsigned)len, f->inode_no);
-#endif
+    /* O_APPEND: re-seek to end before every write (atomic append semantics) */
+    if (f->flags & VFS_O_APPEND) {
+        biscuitfs_inode_t tmp_ino;
+        read_inode(f->inode_no, &tmp_ino);
+        f->offset = tmp_ino.size_lo;
+        f->size   = tmp_ino.size_lo;
+    }
+
+    kprintf("[BISCUITFS] write slot=%d ino=%u offset=%u len=%u\n",
+            fd, f->inode_no, f->offset, (unsigned)len);
 
     uint32_t done = 0;
     uint8_t *blkbuf = biscuitfs_alloc_block_buf(__func__);
@@ -1135,8 +1138,18 @@ static int biscuitfs_write_cb(int fd, const uint8_t *buf, size_t len) {
 }
 
 static int biscuitfs_close_cb(int fd) {
-    if (fd < 0 || fd >= BISCUITFS_MAX_OPEN) return -1;
-    fd_table[fd].used = 0;
+    if (fd < 0 || fd >= BISCUITFS_MAX_OPEN || !fd_table[fd].used) return -1;
+    int rc = --fd_table[fd].refcount;
+    kprintf("[BISCUITFS] close slot=%d refcount->%d\n", fd, rc);
+    if (rc <= 0)
+        fd_table[fd].used = 0;
+    return 0;
+}
+
+static int biscuitfs_addref_cb(int fd) {
+    if (fd < 0 || fd >= BISCUITFS_MAX_OPEN || !fd_table[fd].used) return -1;
+    fd_table[fd].refcount++;
+    kprintf("[BISCUITFS] addref slot=%d refcount->%d\n", fd, fd_table[fd].refcount);
     return 0;
 }
 
@@ -1557,6 +1570,7 @@ static filesystem_t biscuitfs_driver = {
     .read_at  = biscuitfs_read_at_cb,
     .write    = biscuitfs_write_cb,
     .close    = biscuitfs_close_cb,
+    .addref   = biscuitfs_addref_cb,
     .readdir  = biscuitfs_readdir_cb,
     .mkdir    = biscuitfs_mkdir_cb,
     .unlink   = biscuitfs_unlink_cb,

--- a/fs/blueyfs.c
+++ b/fs/blueyfs.c
@@ -768,6 +768,10 @@ static int dir_remove_entry(uint32_t dir_ino, const char *name, uint32_t ino) {
             biscuitfs_dirent_t *de = (biscuitfs_dirent_t *)(blkbuf + off);
             if (de->rec_len == 0) break;
 
+            if (de->inode != 0 && de->name_len > 0)
+                kprintf("[BISCUITFS] dir_remove_entry: de->inode=%u name_len=%u rec_len=%u name=%.16s (want ino=%u name=%s)\n",
+                        de->inode, de->name_len, de->rec_len, de->name, ino, name);
+
             if (de->inode == ino && de->name_len == namelen &&
                 memcmp(de->name, name, namelen) == 0) {
                 if (prev) {
@@ -1183,7 +1187,7 @@ static int biscuitfs_readdir_cb(const char *path, vfs_dirent_t *out, int max) {
 }
 
 static int biscuitfs_mkdir_cb(const char *path) {
-    if (path_to_inode(path)) return -1;
+    if (path_to_inode(path)) return -BLUEY_EEXIST;
 
     // Check if parent exists
     char parent_path[256];
@@ -1280,11 +1284,13 @@ static int biscuitfs_unlink_cb(const char *path) {
     char *slash;
     const char *name;
     uint32_t dir_ino;
-    if (!ino) return -1;
+    kprintf("[BISCUITFS] unlink_cb: path=%s ino=%u\n", path, ino);
+    if (!ino) { kprintf("[BISCUITFS] unlink_cb: path not found\n"); return -1; }
 
     biscuitfs_inode_t inode;
-    if (read_inode(ino, &inode) != 0) return -1;
-    if ((inode.mode & BISCUITFS_IFMT) == BISCUITFS_IFDIR) return -1;
+    if (read_inode(ino, &inode) != 0) { kprintf("[BISCUITFS] unlink_cb: read_inode failed\n"); return -1; }
+    kprintf("[BISCUITFS] unlink_cb: mode=0x%x links=%u size=%u\n", inode.mode, inode.links_count, inode.size_lo);
+    if ((inode.mode & BISCUITFS_IFMT) == BISCUITFS_IFDIR) { kprintf("[BISCUITFS] unlink_cb: is a directory\n"); return -1; }
 
     strncpy(parent_path, path, sizeof(parent_path) - 1);
     parent_path[sizeof(parent_path) - 1] = '\0';
@@ -1292,11 +1298,13 @@ static int biscuitfs_unlink_cb(const char *path) {
     name = slash ? slash + 1 : path;
     if (slash) *slash = '\0';
     dir_ino = path_to_inode(parent_path[0] ? parent_path : "/");
-    if (!dir_ino) return -1;
+    kprintf("[BISCUITFS] unlink_cb: parent=%s dir_ino=%u name=%s\n", parent_path, dir_ino, name);
+    if (!dir_ino) { kprintf("[BISCUITFS] unlink_cb: parent dir not found\n"); return -1; }
 
     biscuitfs_journal_begin();
 
     if (dir_remove_entry(dir_ino, name, ino) != 0) {
+        kprintf("[BISCUITFS] unlink_cb: dir_remove_entry failed dir_ino=%u name=%s ino=%u\n", dir_ino, name, ino);
         biscuitfs_journal_abort();
         return -1;
     }

--- a/fs/blueyfs.c
+++ b/fs/blueyfs.c
@@ -245,7 +245,7 @@ void biscuitfs_journal_replay(void) {
 
         if (read_block(data_blk, dbuf)        == 0 &&
             write_block(tags[i].t_blocknr, dbuf) == 0) {
-            kprintf("[BISCUITFS] Replayed block %d\n", tags[i].t_blocknr);
+            BISCUITFS_DEBUGF("[BISCUITFS] Replayed block %d\n", tags[i].t_blocknr);
         }
         data_blk++;
         if (flags & BISCUITFS_JNL_FLAG_LAST) break;
@@ -943,7 +943,7 @@ static int biscuitfs_open_cb(const char *path, int flags) {
             fd_table[i].flags    = (uint32_t)flags;
             /* O_APPEND: start writing at end of file */
             fd_table[i].offset   = (flags & VFS_O_APPEND) ? inode.size_lo : 0;
-            kprintf("[BISCUITFS] open slot=%d ino=%u size=%u flags=0x%x\n", i, ino, inode.size_lo, (unsigned)flags);
+            BISCUITFS_DEBUGF("[BISCUITFS] open slot=%d ino=%u size=%u flags=0x%x\n", i, ino, inode.size_lo, (unsigned)flags);
             if (flags & VFS_O_TRUNC) {
                 /* Would free data blocks and reset size; omitted for brevity */
                 fd_table[i].size = 0;
@@ -1023,7 +1023,7 @@ static int biscuitfs_read_at_cb(int fd, uint8_t *buf, size_t len, uint32_t offse
 
     if (!blkbuf) return -1;
 
-    kprintf("[BISCUITFS] read_at slot=%d ino=%u offset=%u size=%u len=%u\n",
+    BISCUITFS_DEBUGF("[BISCUITFS] read_at slot=%d ino=%u offset=%u size=%u len=%u\n",
             fd, f->inode_no, offset, f->size, (unsigned)len);
 
     if (offset >= f->size) {
@@ -1082,7 +1082,7 @@ static int biscuitfs_write_cb(int fd, const uint8_t *buf, size_t len) {
         f->size   = tmp_ino.size_lo;
     }
 
-    kprintf("[BISCUITFS] write slot=%d ino=%u offset=%u len=%u\n",
+    BISCUITFS_DEBUGF("[BISCUITFS] write slot=%d ino=%u offset=%u len=%u\n",
             fd, f->inode_no, f->offset, (unsigned)len);
 
     uint32_t done = 0;
@@ -1140,7 +1140,7 @@ static int biscuitfs_write_cb(int fd, const uint8_t *buf, size_t len) {
 static int biscuitfs_close_cb(int fd) {
     if (fd < 0 || fd >= BISCUITFS_MAX_OPEN || !fd_table[fd].used) return -1;
     int rc = --fd_table[fd].refcount;
-    kprintf("[BISCUITFS] close slot=%d refcount->%d\n", fd, rc);
+    BISCUITFS_DEBUGF("[BISCUITFS] close slot=%d refcount->%d\n", fd, rc);
     if (rc <= 0)
         fd_table[fd].used = 0;
     return 0;
@@ -1149,7 +1149,6 @@ static int biscuitfs_close_cb(int fd) {
 static int biscuitfs_addref_cb(int fd) {
     if (fd < 0 || fd >= BISCUITFS_MAX_OPEN || !fd_table[fd].used) return -1;
     fd_table[fd].refcount++;
-    kprintf("[BISCUITFS] addref slot=%d refcount->%d\n", fd, fd_table[fd].refcount);
     return 0;
 }
 
@@ -1298,12 +1297,12 @@ static int biscuitfs_unlink_cb(const char *path) {
     const char *name;
     uint32_t dir_ino;
     kprintf("[BISCUITFS] unlink_cb: path=%s ino=%u\n", path, ino);
-    if (!ino) { kprintf("[BISCUITFS] unlink_cb: path not found\n"); return -1; }
+    if (!ino) return -1;
 
     biscuitfs_inode_t inode;
     if (read_inode(ino, &inode) != 0) { kprintf("[BISCUITFS] unlink_cb: read_inode failed\n"); return -1; }
-    kprintf("[BISCUITFS] unlink_cb: mode=0x%x links=%u size=%u\n", inode.mode, inode.links_count, inode.size_lo);
-    if ((inode.mode & BISCUITFS_IFMT) == BISCUITFS_IFDIR) { kprintf("[BISCUITFS] unlink_cb: is a directory\n"); return -1; }
+    BISCUITFS_DEBUGF("[BISCUITFS] unlink_cb: mode=0x%x links=%u size=%u\n", inode.mode, inode.links_count, inode.size_lo);
+    if ((inode.mode & BISCUITFS_IFMT) == BISCUITFS_IFDIR) return -1;
 
     strncpy(parent_path, path, sizeof(parent_path) - 1);
     parent_path[sizeof(parent_path) - 1] = '\0';
@@ -1311,7 +1310,7 @@ static int biscuitfs_unlink_cb(const char *path) {
     name = slash ? slash + 1 : path;
     if (slash) *slash = '\0';
     dir_ino = path_to_inode(parent_path[0] ? parent_path : "/");
-    kprintf("[BISCUITFS] unlink_cb: parent=%s dir_ino=%u name=%s\n", parent_path, dir_ino, name);
+    BISCUITFS_DEBUGF("[BISCUITFS] unlink_cb: parent=%s dir_ino=%u name=%s\n", parent_path, dir_ino, name);
     if (!dir_ino) { kprintf("[BISCUITFS] unlink_cb: parent dir not found\n"); return -1; }
 
     biscuitfs_journal_begin();

--- a/fs/procfs.c
+++ b/fs/procfs.c
@@ -1,151 +1,646 @@
+// BlueyOS procfs - "Bluey's Report Card"
+// Virtual filesystem exposing kernel state at /proc, similar to Linux procfs.
+// "Write it all down, Bluey — that's how you remember the important stuff!" - Bandit
+// Episode ref: "The Show" - Bluey presents everything clearly and in order
+//
+// ⚠️  VIBE CODED RESEARCH PROJECT — NOT FOR PRODUCTION USE ⚠️
+//
+// Bluey and all related characters are trademarks of Ludo Studio Pty Ltd,
+// licensed by BBC Studios. BlueyOS is an unofficial fan/research project
+// with no affiliation to Ludo Studio or the BBC.
+
 #include "procfs.h"
 
 #include "../include/types.h"
+#include "../include/version.h"
 #include "../kernel/bootargs.h"
+#include "../kernel/kheap.h"
+#include "../kernel/netdev.h"
+#include "../kernel/process.h"
+#include "../kernel/rtc.h"
+#include "../kernel/sysinfo.h"
+#include "../kernel/timer.h"
 #include "../lib/string.h"
+#include "vfs.h"
 
-#define PROCFS_MAX_OPEN 1024
-#define PROCFS_NODE_NONE 0
-#define PROCFS_NODE_CMDLINE 1
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+#define PROCFS_MAX_OPEN  1024
+#define PROCFS_BUF_MAX   2048   /* max bytes for any pre-rendered proc file */
+
+// Node type constants
+#define PROCFS_NODE_NONE        0
+#define PROCFS_NODE_CMDLINE     1   /* /proc/cmdline  — boot kernel command line   */
+#define PROCFS_NODE_UPTIME      2   /* /proc/uptime   — seconds since boot         */
+#define PROCFS_NODE_MEMINFO     3   /* /proc/meminfo  — memory statistics          */
+#define PROCFS_NODE_VERSION     4   /* /proc/version  — kernel version string      */
+#define PROCFS_NODE_LOADAVG     5   /* /proc/loadavg  — load averages (stub)       */
+#define PROCFS_NODE_PID_STATUS  6   /* /proc/<pid>/status  — per-process status    */
+#define PROCFS_NODE_PID_CMDLINE 7   /* /proc/<pid>/cmdline — per-process cmd line  */
+#define PROCFS_NODE_NET_DEV     8   /* /proc/net/dev  — network interface stats    */
+
+// ---------------------------------------------------------------------------
+// Per-fd state
+// ---------------------------------------------------------------------------
 
 typedef struct {
-    int used;
-    uint8_t node;
+    int      used;
+    uint8_t  node;
+    uint8_t  _pad[3];
+    uint32_t pid;       /* PID for PROCFS_NODE_PID_* nodes; 0 otherwise  */
+    char    *buf;       /* kheap_alloc'd pre-rendered content; NULL for CMDLINE */
+    uint32_t buf_len;   /* length of valid bytes in buf                   */
 } procfs_file_t;
 
 static procfs_file_t procfs_files[PROCFS_MAX_OPEN];
 
-static int procfs_is_root_path(const char *path) {
-    if (!path) return 0;
+// ---------------------------------------------------------------------------
+// Minimal buffer formatter (no snprintf in freestanding kernel)
+// ---------------------------------------------------------------------------
+
+typedef struct {
+    char *buf;
+    int   pos;
+    int   max;
+} pbuf_t;
+
+static void pbuf_init(pbuf_t *b, char *buf, int max) {
+    b->buf = buf;
+    b->pos = 0;
+    b->max = max;
+    if (max > 0) buf[0] = '\0';
+}
+
+static void pbuf_char(pbuf_t *b, char c) {
+    if (b->pos < b->max - 1) {
+        b->buf[b->pos++] = c;
+        b->buf[b->pos] = '\0';
+    }
+}
+
+static void pbuf_str(pbuf_t *b, const char *s) {
+    if (!s) return;
+    while (*s) pbuf_char(b, *s++);
+}
+
+static void pbuf_uint32(pbuf_t *b, uint32_t v) {
+    char tmp[12];
+    int i = 0;
+    if (v == 0) { pbuf_char(b, '0'); return; }
+    while (v > 0 && i < 11) { tmp[i++] = (char)('0' + v % 10); v /= 10; }
+    while (i > 0) pbuf_char(b, tmp[--i]);
+}
+
+/* Print exactly two decimal digits (for sub-second fractions). */
+static void pbuf_2digits(pbuf_t *b, uint32_t v) {
+    v %= 100u;
+    pbuf_char(b, (char)('0' + v / 10u));
+    pbuf_char(b, (char)('0' + v % 10u));
+}
+
+/* Convert uint32_t to a NUL-terminated decimal string in caller-provided buf. */
+static void u32_to_str(uint32_t v, char *buf, int bufsz) {
+    char tmp[12];
+    int ti = 0, pi = 0;
+    if (bufsz <= 0) return;
+    if (v == 0) { if (bufsz > 1) { buf[0] = '0'; buf[1] = '\0'; } return; }
+    while (v > 0 && ti < 11) { tmp[ti++] = (char)('0' + v % 10); v /= 10; }
+    while (ti > 0 && pi < bufsz - 1) buf[pi++] = tmp[--ti];
+    buf[pi] = '\0';
+}
+
+// ---------------------------------------------------------------------------
+// Path-checking helpers
+// ---------------------------------------------------------------------------
+
+static int procfs_is_root(const char *path) {
     return strcmp(path, "/proc") == 0 || strcmp(path, "/proc/") == 0;
 }
 
-static int procfs_is_cmdline_path(const char *path) {
-    if (!path) return 0;
-    return strcmp(path, "/proc/cmdline") == 0;
+static int procfs_is_net_dir(const char *path) {
+    return strcmp(path, "/proc/net") == 0 || strcmp(path, "/proc/net/") == 0;
 }
 
-static size_t procfs_cmdline_size(void) {
-    size_t len = strlen(boot_args_cmdline());
+/*
+ * Parse /proc/<N>[/subpath] or /proc/self[/subpath].
+ * Returns the PID (>0) and sets *subpath to the part after the slash
+ * (e.g. "status", "cmdline", or "" for the directory itself).
+ * Returns 0 if the path is not a numeric/self PID path.
+ */
+static uint32_t procfs_parse_pid(const char *path, const char **subpath) {
+    if (!path || strncmp(path, "/proc/", 6) != 0) return 0;
 
-    return len > 0 ? len + 1 : 1;
+    const char *p = path + 6;  /* skip "/proc/" */
+
+    /* /proc/self — alias for the current process */
+    if (strncmp(p, "self", 4) == 0 && (p[4] == '/' || p[4] == '\0')) {
+        process_t *cur = process_current();
+        if (!cur) return 0;
+        p += 4;
+        if (*p == '/') p++;
+        if (subpath) *subpath = p;
+        return cur->pid;
+    }
+
+    /* Numeric PID */
+    if (*p < '0' || *p > '9') return 0;
+    uint32_t pid = 0;
+    while (*p >= '0' && *p <= '9') {
+        pid = pid * 10u + (uint32_t)(*p - '0');
+        p++;
+    }
+    if (pid == 0) return 0;
+    if (*p == '/') p++;
+    if (subpath) *subpath = p;
+    return pid;
 }
+
+// ---------------------------------------------------------------------------
+// Per-process state helpers
+// ---------------------------------------------------------------------------
+
+static char procfs_state_char(proc_state_t s) {
+    switch (s) {
+        case PROC_RUNNING:  return 'R';
+        case PROC_READY:    return 'R';
+        case PROC_SLEEPING: return 'S';
+        case PROC_WAITING:  return 'D';
+        case PROC_STOPPED:  return 'T';
+        case PROC_ZOMBIE:   return 'Z';
+        default:            return '?';
+    }
+}
+
+static const char *procfs_state_name(proc_state_t s) {
+    switch (s) {
+        case PROC_RUNNING:  return "running";
+        case PROC_READY:    return "sleeping";
+        case PROC_SLEEPING: return "sleeping";
+        case PROC_WAITING:  return "disk sleep";
+        case PROC_STOPPED:  return "stopped";
+        case PROC_ZOMBIE:   return "zombie";
+        default:            return "unknown";
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Content render functions
+// ---------------------------------------------------------------------------
+
+static void render_uptime(pbuf_t *b) {
+    uint32_t secs       = rtc_get_uptime_seconds();
+    uint32_t hundredths = (timer_get_ticks() % 1000u) / 10u;
+    pbuf_uint32(b, secs);
+    pbuf_char(b, '.');
+    pbuf_2digits(b, hundredths);
+    /* We do not track per-CPU idle time; report 0.00 */
+    pbuf_str(b, " 0.00\n");
+}
+
+static void render_meminfo(pbuf_t *b) {
+    uint32_t total_bytes, used_bytes, free_bytes;
+    kheap_get_stats(&total_bytes, &used_bytes, &free_bytes);
+
+    uint32_t ram_mb       = sysinfo_get_ram_mb();
+    uint32_t ram_kb       = ram_mb * 1024u;
+    uint32_t heap_free_kb = free_bytes / 1024u;
+    uint32_t heap_used_kb = used_bytes / 1024u;
+
+    /* Standard Linux /proc/meminfo fields (subset) */
+    pbuf_str(b, "MemTotal:        "); pbuf_uint32(b, ram_kb);       pbuf_str(b, " kB\n");
+    pbuf_str(b, "MemFree:         "); pbuf_uint32(b, heap_free_kb); pbuf_str(b, " kB\n");
+    pbuf_str(b, "MemAvailable:    "); pbuf_uint32(b, heap_free_kb); pbuf_str(b, " kB\n");
+    pbuf_str(b, "Buffers:         0 kB\n");
+    pbuf_str(b, "Cached:          0 kB\n");
+    pbuf_str(b, "SwapCached:      0 kB\n");
+    pbuf_str(b, "SwapTotal:       0 kB\n");
+    pbuf_str(b, "SwapFree:        0 kB\n");
+    /* BlueyOS-specific: kernel heap detail */
+    pbuf_str(b, "KernelHeap:      "); pbuf_uint32(b, total_bytes / 1024u); pbuf_str(b, " kB\n");
+    pbuf_str(b, "KernelHeapUsed:  "); pbuf_uint32(b, heap_used_kb);        pbuf_str(b, " kB\n");
+    pbuf_str(b, "KernelHeapFree:  "); pbuf_uint32(b, heap_free_kb);        pbuf_str(b, " kB\n");
+}
+
+static void render_version(pbuf_t *b) {
+    pbuf_str(b, BLUEYOS_VERSION_STRING);
+    pbuf_str(b, " (");
+    pbuf_str(b, BLUEYOS_BUILD_USER);
+    pbuf_char(b, '@');
+    pbuf_str(b, BLUEYOS_BUILD_HOST);
+    pbuf_str(b, ") #");
+    pbuf_str(b, BLUEYOS_BUILD_NUMBER_STR);
+    pbuf_char(b, ' ');
+    pbuf_str(b, BLUEYOS_BUILD_DATE);
+    pbuf_char(b, ' ');
+    pbuf_str(b, BLUEYOS_BUILD_TIME);
+    pbuf_char(b, '\n');
+}
+
+static void render_loadavg(pbuf_t *b) {
+    /* We do not implement load tracking; report all zeroes. */
+    int total = 0;
+    process_t *p = process_first();
+    while (p) {
+        if (p->state != PROC_DEAD) total++;
+        p = process_next(p);
+    }
+
+    uint32_t cur_pid = 0;
+    process_t *cur = process_current();
+    if (cur) cur_pid = cur->pid;
+
+    pbuf_str(b, "0.00 0.00 0.00 1/");
+    pbuf_uint32(b, (uint32_t)total);
+    pbuf_char(b, ' ');
+    pbuf_uint32(b, cur_pid);
+    pbuf_char(b, '\n');
+}
+
+static void render_pid_status(pbuf_t *b, uint32_t pid) {
+    process_t *p = process_get_by_pid(pid);
+    if (!p) {
+        pbuf_str(b, "Name:\t(unknown)\n");
+        return;
+    }
+
+    /* Approximate virtual memory size from heap + stack regions */
+    uint32_t heap_sz = (p->brk_current > p->brk_base)
+                       ? p->brk_current - p->brk_base : 0u;
+    uint32_t stk_sz  = (p->user_stack_top > p->user_stack_base)
+                       ? p->user_stack_top - p->user_stack_base : 0u;
+    uint32_t vm_kb   = (heap_sz + stk_sz) / 1024u;
+
+    pbuf_str(b, "Name:\t"); pbuf_str(b, p->name);           pbuf_char(b, '\n');
+    pbuf_str(b, "State:\t"); pbuf_char(b, procfs_state_char(p->state));
+    pbuf_str(b, " ("); pbuf_str(b, procfs_state_name(p->state)); pbuf_str(b, ")\n");
+    pbuf_str(b, "Pid:\t");   pbuf_uint32(b, p->pid);         pbuf_char(b, '\n');
+    pbuf_str(b, "PPid:\t");  pbuf_uint32(b, p->parent_pid);  pbuf_char(b, '\n');
+    pbuf_str(b, "Uid:\t");
+        pbuf_uint32(b, p->uid);  pbuf_char(b, '\t');
+        pbuf_uint32(b, p->uid);  pbuf_char(b, '\t');
+        pbuf_uint32(b, p->euid); pbuf_char(b, '\t');
+        pbuf_uint32(b, p->euid); pbuf_char(b, '\n');
+    pbuf_str(b, "Gid:\t");
+        pbuf_uint32(b, p->gid);  pbuf_char(b, '\t');
+        pbuf_uint32(b, p->gid);  pbuf_char(b, '\t');
+        pbuf_uint32(b, p->egid); pbuf_char(b, '\t');
+        pbuf_uint32(b, p->egid); pbuf_char(b, '\n');
+    pbuf_str(b, "VmSize:\t"); pbuf_uint32(b, vm_kb); pbuf_str(b, " kB\n");
+    pbuf_str(b, "VmRSS:\t");  pbuf_uint32(b, vm_kb); pbuf_str(b, " kB\n");
+    pbuf_str(b, "Threads:\t1\n");
+}
+
+/*
+ * /proc/<pid>/cmdline — NUL-separated argument list (Linux-compatible).
+ * We store only the process name since we do not keep full argv[].
+ */
+static void render_pid_cmdline(pbuf_t *b, uint32_t pid) {
+    process_t *p = process_get_by_pid(pid);
+    if (p) {
+        pbuf_str(b, p->name);
+        pbuf_char(b, '\0');   /* Linux: args are NUL-separated, final NUL */
+    }
+}
+
+static void render_net_dev(pbuf_t *b) {
+    pbuf_str(b, "Inter-|   Receive                                                |  Transmit\n");
+    pbuf_str(b, " face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed\n");
+
+    netdev_device_t *devs[NETDEV_MAX_DEVICES];
+    int count = 0;
+    netdev_list_all(devs, &count, NETDEV_MAX_DEVICES);
+
+    for (int i = 0; i < count; i++) {
+        netdev_device_t *dev = devs[i];
+        if (!dev) continue;
+
+        /* Right-justify the interface name in a 6-char field */
+        int nlen = (int)strlen(dev->name);
+        for (int j = nlen; j < 6; j++) pbuf_char(b, ' ');
+        pbuf_str(b, dev->name);
+        pbuf_str(b, ": ");
+
+        /* Receive counters */
+        pbuf_uint32(b, dev->rx_bytes);   pbuf_char(b, ' ');
+        pbuf_uint32(b, dev->rx_packets); pbuf_char(b, ' ');
+        pbuf_uint32(b, dev->rx_errors);
+        pbuf_str(b, " 0 0 0 0 0 ");
+
+        /* Transmit counters */
+        pbuf_uint32(b, dev->tx_bytes);   pbuf_char(b, ' ');
+        pbuf_uint32(b, dev->tx_packets); pbuf_char(b, ' ');
+        pbuf_uint32(b, dev->tx_errors);
+        pbuf_str(b, " 0 0 0 0 0\n");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Filesystem vtable callbacks
+// ---------------------------------------------------------------------------
 
 static int procfs_mount_cb(const char *mountpoint, uint32_t start_lba) {
     (void)mountpoint;
     (void)start_lba;
-
     memset(procfs_files, 0, sizeof(procfs_files));
     return 0;
 }
 
-static int procfs_open_cb(const char *path, int flags) {
-    if (!procfs_is_cmdline_path(path)) return -1;
-    if ((flags & (VFS_O_WRONLY | VFS_O_RDWR | VFS_O_CREAT | VFS_O_TRUNC | VFS_O_APPEND)) != 0) {
-        return -1;
+static int procfs_alloc_fd(void) {
+    for (int i = 0; i < PROCFS_MAX_OPEN; i++) {
+        if (!procfs_files[i].used) return i;
     }
-
-    for (int index = 0; index < PROCFS_MAX_OPEN; index++) {
-        if (procfs_files[index].used) continue;
-        procfs_files[index].used = 1;
-        procfs_files[index].node = PROCFS_NODE_CMDLINE;
-        return index;
-    }
-
     return -1;
 }
 
+static int procfs_open_cb(const char *path, int flags) {
+    if (!path) return -1;
+
+    /* procfs is read-only; reject any write-mode flags */
+    if ((flags & (VFS_O_WRONLY | VFS_O_RDWR | VFS_O_CREAT |
+                  VFS_O_TRUNC  | VFS_O_APPEND)) != 0) return -1;
+
+    int fd = procfs_alloc_fd();
+    if (fd < 0) return -1;
+
+    uint8_t  node    = PROCFS_NODE_NONE;
+    uint32_t pid     = 0;
+    char    *buf     = NULL;
+    uint32_t buf_len = 0;
+
+    /* --- Static system-wide files ---------------------------------------- */
+    if (strcmp(path, "/proc/cmdline") == 0) {
+        node = PROCFS_NODE_CMDLINE;   /* rendered on-the-fly in read_at */
+
+    } else if (strcmp(path, "/proc/uptime")  == 0) { node = PROCFS_NODE_UPTIME;
+    } else if (strcmp(path, "/proc/meminfo") == 0) { node = PROCFS_NODE_MEMINFO;
+    } else if (strcmp(path, "/proc/version") == 0) { node = PROCFS_NODE_VERSION;
+    } else if (strcmp(path, "/proc/loadavg") == 0) { node = PROCFS_NODE_LOADAVG;
+    } else if (strcmp(path, "/proc/net/dev") == 0) { node = PROCFS_NODE_NET_DEV;
+
+    /* --- Per-process files ------------------------------------------------ */
+    } else {
+        const char *sub = NULL;
+        pid = procfs_parse_pid(path, &sub);
+        if (!pid) return -1;
+        if (!process_get_by_pid(pid)) return -1;
+
+        if (!sub || sub[0] == '\0') {
+            /* /proc/<pid>/ is a directory — not a regular file */
+            return -1;
+        } else if (strcmp(sub, "status")  == 0) {
+            node = PROCFS_NODE_PID_STATUS;
+        } else if (strcmp(sub, "cmdline") == 0) {
+            node = PROCFS_NODE_PID_CMDLINE;
+        } else {
+            return -1;
+        }
+    }
+
+    if (node == PROCFS_NODE_NONE) return -1;
+
+    /* Pre-render content into a heap-allocated buffer for all nodes except
+     * CMDLINE (which uses boot_args_cmdline() directly on every read). */
+    if (node != PROCFS_NODE_CMDLINE) {
+        buf = (char *)kheap_alloc(PROCFS_BUF_MAX, 0);
+        if (!buf) return -1;
+
+        pbuf_t pb;
+        pbuf_init(&pb, buf, PROCFS_BUF_MAX);
+
+        switch (node) {
+            case PROCFS_NODE_UPTIME:      render_uptime(&pb);           break;
+            case PROCFS_NODE_MEMINFO:     render_meminfo(&pb);          break;
+            case PROCFS_NODE_VERSION:     render_version(&pb);          break;
+            case PROCFS_NODE_LOADAVG:     render_loadavg(&pb);          break;
+            case PROCFS_NODE_PID_STATUS:  render_pid_status(&pb, pid);  break;
+            case PROCFS_NODE_PID_CMDLINE: render_pid_cmdline(&pb, pid); break;
+            case PROCFS_NODE_NET_DEV:     render_net_dev(&pb);          break;
+            default: break;
+        }
+        buf_len = (uint32_t)pb.pos;
+    }
+
+    procfs_files[fd].used    = 1;
+    procfs_files[fd].node    = node;
+    procfs_files[fd].pid     = pid;
+    procfs_files[fd].buf     = buf;
+    procfs_files[fd].buf_len = buf_len;
+    return fd;
+}
+
 static int procfs_read_at_cb(int fd, uint8_t *buf, size_t len, uint32_t offset) {
-    const char *cmdline;
-    size_t cmdline_len;
-    size_t total_len;
-    size_t copied = 0;
-
     if (fd < 0 || fd >= PROCFS_MAX_OPEN || !procfs_files[fd].used) return -1;
-    if (procfs_files[fd].node != PROCFS_NODE_CMDLINE) return -1;
     if (!buf) return -1;
+    if (len == 0) return 0;
 
-    cmdline = boot_args_cmdline();
-    cmdline_len = strlen(cmdline);
-    total_len = procfs_cmdline_size();
-    if (offset >= total_len) return 0;
+    /* /proc/cmdline: regenerate on every read (boot cmdline is static anyway) */
+    if (procfs_files[fd].node == PROCFS_NODE_CMDLINE) {
+        const char *cmdline     = boot_args_cmdline();
+        size_t      cmdline_len = strlen(cmdline);
+        size_t      total       = cmdline_len > 0 ? cmdline_len + 1u : 1u;
 
-    if (offset < cmdline_len) {
-        size_t remaining = cmdline_len - offset;
-        size_t chunk = len < remaining ? len : remaining;
-        memcpy(buf, cmdline + offset, chunk);
-        copied = chunk;
+        if (offset >= (uint32_t)total) return 0;
+
+        size_t copied = 0;
+        if (offset < cmdline_len) {
+            size_t remaining = cmdline_len - offset;
+            size_t chunk     = len < remaining ? len : remaining;
+            memcpy(buf, cmdline + offset, chunk);
+            copied = chunk;
+        }
+        if (copied < len && offset + copied < total) {
+            buf[copied++] = '\n';
+        }
+        return (int)copied;
     }
 
-    if (copied < len && offset + copied < total_len) {
-        buf[copied++] = '\n';
-    }
+    /* All other nodes: serve from the pre-rendered buffer */
+    const char *src     = procfs_files[fd].buf;
+    uint32_t    src_len = procfs_files[fd].buf_len;
 
-    return (int)copied;
+    if (!src || offset >= src_len) return 0;
+    size_t avail = src_len - offset;
+    size_t chunk = len < avail ? len : avail;
+    memcpy(buf, src + offset, chunk);
+    return (int)chunk;
 }
 
 static int procfs_close_cb(int fd) {
     if (fd < 0 || fd >= PROCFS_MAX_OPEN) return -1;
-    procfs_files[fd].used = 0;
-    procfs_files[fd].node = PROCFS_NODE_NONE;
+    if (procfs_files[fd].buf) kheap_free(procfs_files[fd].buf);
+    memset(&procfs_files[fd], 0, sizeof(procfs_files[fd]));
     return 0;
 }
 
 static int procfs_readdir_cb(const char *path, vfs_dirent_t *out, int max) {
-    if (!procfs_is_root_path(path) || !out || max <= 0) return -1;
+    if (!out || max <= 0) return -1;
 
-    memset(&out[0], 0, sizeof(out[0]));
-    strncpy(out[0].name, "cmdline", sizeof(out[0].name) - 1);
-    out[0].size = (uint32_t)procfs_cmdline_size();
-    out[0].inode = PROCFS_NODE_CMDLINE;
-    out[0].is_dir = 0;
-    return 1;
-}
+    /* --- /proc root directory -------------------------------------------- */
+    if (procfs_is_root(path)) {
+        static const struct { const char *name; uint32_t inode; uint8_t is_dir; }
+        static_entries[] = {
+            { "cmdline", 1, 0 },
+            { "uptime",  2, 0 },
+            { "meminfo", 3, 0 },
+            { "version", 4, 0 },
+            { "loadavg", 5, 0 },
+            { "net",     6, 1 },
+        };
+        static const int N_STATIC = (int)(sizeof(static_entries)/sizeof(static_entries[0]));
 
-static int procfs_stat_cb(const char *path, vfs_stat_t *out) {
-    if (!out) return -1;
+        int n = 0;
+        for (int i = 0; i < N_STATIC && n < max; i++) {
+            memset(&out[n], 0, sizeof(out[n]));
+            strncpy(out[n].name, static_entries[i].name, sizeof(out[n].name) - 1);
+            out[n].inode  = static_entries[i].inode;
+            out[n].is_dir = static_entries[i].is_dir;
+            n++;
+        }
 
-    memset(out, 0, sizeof(*out));
-    out->uid = 0;
-    out->gid = 0;
-
-    if (procfs_is_root_path(path)) {
-        out->mode = VFS_S_IFDIR | VFS_S_IRUSR | VFS_S_IXUSR |
-                    VFS_S_IRGRP | VFS_S_IXGRP |
-                    VFS_S_IROTH | VFS_S_IXOTH;
-        out->is_dir = 1;
-        return 0;
+        /* Per-process directories (one entry per live process) */
+        process_t *p = process_first();
+        while (p && n < max) {
+            if (p->state != PROC_DEAD) {
+                char pid_str[12];
+                u32_to_str(p->pid, pid_str, sizeof(pid_str));
+                memset(&out[n], 0, sizeof(out[n]));
+                strncpy(out[n].name, pid_str, sizeof(out[n].name) - 1);
+                out[n].inode  = 100u + p->pid;   /* offset to avoid clash with static inodes */
+                out[n].is_dir = 1;
+                n++;
+            }
+            p = process_next(p);
+        }
+        return n;
     }
 
-    if (procfs_is_cmdline_path(path)) {
-        out->mode = VFS_S_IFREG | VFS_S_IRUSR | VFS_S_IRGRP | VFS_S_IROTH;
-        out->size = (uint32_t)procfs_cmdline_size();
-        out->is_dir = 0;
-        return 0;
+    /* --- /proc/net directory --------------------------------------------- */
+    if (procfs_is_net_dir(path)) {
+        if (max < 1) return 0;
+        memset(&out[0], 0, sizeof(out[0]));
+        strncpy(out[0].name, "dev", sizeof(out[0].name) - 1);
+        out[0].inode  = 1;
+        out[0].is_dir = 0;
+        return 1;
+    }
+
+    /* --- /proc/<pid> directory ------------------------------------------- */
+    {
+        const char *sub = NULL;
+        uint32_t pid = procfs_parse_pid(path, &sub);
+        if (pid && process_get_by_pid(pid) && (!sub || sub[0] == '\0')) {
+            int n = 0;
+            static const char *pid_entries[] = { "status", "cmdline" };
+            for (int i = 0; i < 2 && n < max; i++) {
+                memset(&out[n], 0, sizeof(out[n]));
+                strncpy(out[n].name, pid_entries[i], sizeof(out[n].name) - 1);
+                out[n].inode  = pid * 10u + (uint32_t)(i + 1u);
+                out[n].is_dir = 0;
+                n++;
+            }
+            return n;
+        }
     }
 
     return -1;
 }
 
-static filesystem_t procfs_fs = {
-    .name = "procfs",
-    .mount = procfs_mount_cb,
-    .open = procfs_open_cb,
-    .read = NULL,
-    .read_at = procfs_read_at_cb,
-    .write = NULL,
-    .close = procfs_close_cb,
-    .readdir = procfs_readdir_cb,
-    .mkdir = NULL,
-    .unlink = NULL,
-    .stat = procfs_stat_cb,
-    .link = NULL,
-    .symlink = NULL,
+static int procfs_stat_cb(const char *path, vfs_stat_t *out) {
+    if (!out) return -1;
+    memset(out, 0, sizeof(*out));
+
+    /* /proc root */
+    if (procfs_is_root(path)) {
+        out->mode   = VFS_S_IFDIR | VFS_S_IRUSR | VFS_S_IXUSR |
+                      VFS_S_IRGRP | VFS_S_IXGRP |
+                      VFS_S_IROTH | VFS_S_IXOTH;
+        out->is_dir = 1;
+        out->inode  = 1;
+        return 0;
+    }
+
+    /* /proc/net directory */
+    if (procfs_is_net_dir(path)) {
+        out->mode   = VFS_S_IFDIR | VFS_S_IRUSR | VFS_S_IXUSR |
+                      VFS_S_IRGRP | VFS_S_IXGRP |
+                      VFS_S_IROTH | VFS_S_IXOTH;
+        out->is_dir = 1;
+        out->inode  = 6;
+        return 0;
+    }
+
+    /* Static regular files */
+    if (strcmp(path, "/proc/cmdline") == 0) {
+        size_t len = strlen(boot_args_cmdline());
+        out->mode  = VFS_S_IFREG | VFS_S_IRUSR | VFS_S_IRGRP | VFS_S_IROTH;
+        out->size  = (uint32_t)(len > 0 ? len + 1u : 1u);
+        out->inode = 1;
+        return 0;
+    }
+    if (strcmp(path, "/proc/uptime")    == 0 ||
+        strcmp(path, "/proc/meminfo")   == 0 ||
+        strcmp(path, "/proc/version")   == 0 ||
+        strcmp(path, "/proc/loadavg")   == 0 ||
+        strcmp(path, "/proc/net/dev")   == 0) {
+        out->mode  = VFS_S_IFREG | VFS_S_IRUSR | VFS_S_IRGRP | VFS_S_IROTH;
+        out->size  = 0;   /* dynamic; unknown without rendering */
+        out->inode = 0;
+        return 0;
+    }
+
+    /* /proc/<pid> and /proc/<pid>/{status,cmdline} */
+    {
+        const char *sub = NULL;
+        uint32_t pid = procfs_parse_pid(path, &sub);
+        if (pid) {
+            process_t *p = process_get_by_pid(pid);
+            if (!p) return -1;
+
+            if (!sub || sub[0] == '\0') {
+                /* /proc/<pid>/ — directory owned by the process's uid/gid */
+                out->mode   = VFS_S_IFDIR | VFS_S_IRUSR | VFS_S_IXUSR |
+                              VFS_S_IRGRP | VFS_S_IXGRP |
+                              VFS_S_IROTH | VFS_S_IXOTH;
+                out->uid    = p->uid;
+                out->gid    = p->gid;
+                out->inode  = 100u + pid;
+                out->is_dir = 1;
+                return 0;
+            }
+            if (strcmp(sub, "status") == 0 || strcmp(sub, "cmdline") == 0) {
+                out->mode  = VFS_S_IFREG | VFS_S_IRUSR | VFS_S_IRGRP | VFS_S_IROTH;
+                out->uid   = p->uid;
+                out->gid   = p->gid;
+                out->inode = pid * 10u + (strcmp(sub, "status") == 0 ? 1u : 2u);
+                return 0;
+            }
+        }
+    }
+
+    return -1;
+}
+
+static filesystem_t procfs_vtable = {
+    .name     = "procfs",
+    .mount    = procfs_mount_cb,
+    .open     = procfs_open_cb,
+    .read     = NULL,
+    .read_at  = procfs_read_at_cb,
+    .write    = NULL,
+    .close    = procfs_close_cb,
+    .readdir  = procfs_readdir_cb,
+    .mkdir    = NULL,
+    .unlink   = NULL,
+    .stat     = procfs_stat_cb,
+    .link     = NULL,
+    .symlink  = NULL,
     .readlink = NULL,
-    .chmod = NULL,
-    .chown = NULL,
+    .chmod    = NULL,
+    .chown    = NULL,
 };
 
 filesystem_t *procfs_get_filesystem(void) {
-    return &procfs_fs;
+    return &procfs_vtable;
 }

--- a/fs/procfs.c
+++ b/fs/procfs.c
@@ -28,7 +28,9 @@
 // ---------------------------------------------------------------------------
 
 #define PROCFS_MAX_OPEN  1024
-#define PROCFS_BUF_MAX   2048   /* max bytes for any pre-rendered proc file */
+#define PROCFS_BUF_MAX   2048   /* max bytes for any pre-rendered proc file;
+                                 * sufficient for net/dev: 2-line header (~140 B)
+                                 * + NETDEV_MAX_DEVICES(8) * ~100 B/line < 2048 */
 
 // Node type constants
 #define PROCFS_NODE_NONE        0
@@ -176,7 +178,7 @@ static char procfs_state_char(proc_state_t s) {
 static const char *procfs_state_name(proc_state_t s) {
     switch (s) {
         case PROC_RUNNING:  return "running";
-        case PROC_READY:    return "sleeping";
+        case PROC_READY:    return "running";   /* runnable, waiting for CPU */
         case PROC_SLEEPING: return "sleeping";
         case PROC_WAITING:  return "disk sleep";
         case PROC_STOPPED:  return "stopped";
@@ -190,6 +192,7 @@ static const char *procfs_state_name(proc_state_t s) {
 // ---------------------------------------------------------------------------
 
 static void render_uptime(pbuf_t *b) {
+    /* timer_init(1000) gives 1000 Hz (1 ms per tick); hundredths = ms / 10 */
     uint32_t secs       = rtc_get_uptime_seconds();
     uint32_t hundredths = (timer_get_ticks() % 1000u) / 10u;
     pbuf_uint32(b, secs);
@@ -499,7 +502,15 @@ static int procfs_readdir_cb(const char *path, vfs_dirent_t *out, int max) {
             n++;
         }
 
-        /* Per-process directories (one entry per live process) */
+        /* Per-process directories (one entry per live process).
+         * Inode ranges (no overlap):
+         *   1-8     : /proc root + static files
+         *   9       : /proc/net directory
+         *   10-19   : /proc/net files (/proc/net/dev = 10)
+         *   1000+pid: /proc/<pid>/ directory
+         *   2000+pid: /proc/<pid>/status
+         *   3000+pid: /proc/<pid>/cmdline
+         * MAX_PROCESSES=64, so max pid inode is 3064 — no overlap. */
         process_t *p = process_first();
         while (p && n < max) {
             if (p->state != PROC_DEAD) {
@@ -507,7 +518,7 @@ static int procfs_readdir_cb(const char *path, vfs_dirent_t *out, int max) {
                 u32_to_str(p->pid, pid_str, sizeof(pid_str));
                 memset(&out[n], 0, sizeof(out[n]));
                 strncpy(out[n].name, pid_str, sizeof(out[n].name) - 1);
-                out[n].inode  = 100u + p->pid;   /* offset to avoid clash with static inodes */
+                out[n].inode  = 1000u + p->pid;
                 out[n].is_dir = 1;
                 n++;
             }
@@ -521,7 +532,7 @@ static int procfs_readdir_cb(const char *path, vfs_dirent_t *out, int max) {
         if (max < 1) return 0;
         memset(&out[0], 0, sizeof(out[0]));
         strncpy(out[0].name, "dev", sizeof(out[0].name) - 1);
-        out[0].inode  = 1;
+        out[0].inode  = 10;   /* /proc/net/dev: inode 10 (range 10-19 reserved for /proc/net) */
         out[0].is_dir = 0;
         return 1;
     }
@@ -536,7 +547,8 @@ static int procfs_readdir_cb(const char *path, vfs_dirent_t *out, int max) {
             for (int i = 0; i < 2 && n < max; i++) {
                 memset(&out[n], 0, sizeof(out[n]));
                 strncpy(out[n].name, pid_entries[i], sizeof(out[n].name) - 1);
-                out[n].inode  = pid * 10u + (uint32_t)(i + 1u);
+                /* status → 2000+pid, cmdline → 3000+pid */
+                out[n].inode  = (i == 0 ? 2000u : 3000u) + pid;
                 out[n].is_dir = 0;
                 n++;
             }
@@ -567,7 +579,7 @@ static int procfs_stat_cb(const char *path, vfs_stat_t *out) {
                       VFS_S_IRGRP | VFS_S_IXGRP |
                       VFS_S_IROTH | VFS_S_IXOTH;
         out->is_dir = 1;
-        out->inode  = 6;
+        out->inode  = 9;   /* /proc/net: inode 9 */
         return 0;
     }
 
@@ -605,7 +617,7 @@ static int procfs_stat_cb(const char *path, vfs_stat_t *out) {
                               VFS_S_IROTH | VFS_S_IXOTH;
                 out->uid    = p->uid;
                 out->gid    = p->gid;
-                out->inode  = 100u + pid;
+                out->inode  = 1000u + pid;
                 out->is_dir = 1;
                 return 0;
             }
@@ -613,7 +625,7 @@ static int procfs_stat_cb(const char *path, vfs_stat_t *out) {
                 out->mode  = VFS_S_IFREG | VFS_S_IRUSR | VFS_S_IRGRP | VFS_S_IROTH;
                 out->uid   = p->uid;
                 out->gid   = p->gid;
-                out->inode = pid * 10u + (strcmp(sub, "status") == 0 ? 1u : 2u);
+                out->inode = strcmp(sub, "status") == 0 ? 2000u + pid : 3000u + pid;
                 return 0;
             }
         }

--- a/fs/vfs.c
+++ b/fs/vfs.c
@@ -30,16 +30,6 @@ static int vfs_dbg_log_limited(int *counter, int limit) {
 }
 
 // Open file descriptor table
-typedef struct {
-    int      used;
-    int      fs_idx;        // which mount point
-    int      fs_fd;         // fd returned by the underlying fs / pipe index
-    char     path[VFS_PATH_LEN];
-    uint8_t  fd_type;       // VFS_FD_TYPE_FILE, VFS_FD_TYPE_DEVEV, or VFS_FD_TYPE_PIPE
-    uint8_t  pipe_is_write; // 1 = write end of a pipe, 0 = read end
-    uint32_t offset;        // current seek position (for lseek / sequential reads)
-} vfs_fd_t;
-
 static vfs_fd_t fd_table_static[VFS_MAX_OPEN];
 static vfs_fd_t *fd_table = fd_table_static;
 static int vfs_fd_capacity = VFS_MAX_OPEN;
@@ -61,6 +51,23 @@ typedef struct {
 
 static vfs_pipe_t pipe_pool[VFS_MAX_PIPES];
 
+/*
+ * Return the fd table for the currently executing process.
+ * Before any user process runs (proc_current is NULL or not yet in user mode),
+ * fall back to the global boot table so kernel init code still works.
+ */
+static vfs_fd_t *current_fd_table(void) {
+    process_t *p = process_current();
+    if (p && (p->flags & PROC_FLAG_USER_MODE)) return p->fd_table;
+    return fd_table;
+}
+
+static int current_fd_capacity(void) {
+    process_t *p = process_current();
+    if (p && (p->flags & PROC_FLAG_USER_MODE)) return VFS_MAX_OPEN;
+    return vfs_fd_capacity;
+}
+
 int vfs_get_last_error(void) {
     return vfs_last_error;
 }
@@ -71,6 +78,8 @@ static void vfs_set_last_error(int err) {
 
 static int vfs_effective_fd_limit(void) {
     process_t *current = process_current();
+    /* Per-process tables are fixed at VFS_MAX_OPEN entries. */
+    if (current && (current->flags & PROC_FLAG_USER_MODE)) return VFS_MAX_OPEN;
     uint32_t limit = current ? current->rlimit_nofile_cur : VFS_MAX_OPEN;
 
     if (limit == 0xFFFFFFFFu || limit > (uint32_t)VFS_MAX_OPEN_HARD) {
@@ -298,9 +307,9 @@ static int vfs_alloc_fd(void) {
     int limit = vfs_effective_fd_limit();
 
     for (;;) {
-        int search_limit = vfs_fd_capacity < limit ? vfs_fd_capacity : limit;
+        int search_limit = current_fd_capacity() < limit ? current_fd_capacity() : limit;
         for (int i = 3; i < search_limit; i++) {  // 0,1,2 = stdin/stdout/stderr
-            if (!fd_table[i].used) {
+            if (!current_fd_table()[i].used) {
                 vfs_set_last_error(VFS_ERR_NONE);
                 return i;
             }
@@ -322,12 +331,12 @@ int vfs_devev_open(void) {
     int fd = vfs_alloc_fd();
     if (fd < 0) { kprintf("[VFS]  Out of file descriptors!\n"); return -1; }
 
-    fd_table[fd].used    = 1;
-    fd_table[fd].fd_type = VFS_FD_TYPE_DEVEV;
-    fd_table[fd].fs_idx  = -1;
-    fd_table[fd].fs_fd   = -1;
-    fd_table[fd].offset  = 0;
-    fd_table[fd].path[0] = '\0';
+    current_fd_table()[fd].used    = 1;
+    current_fd_table()[fd].fd_type = VFS_FD_TYPE_DEVEV;
+    current_fd_table()[fd].fs_idx  = -1;
+    current_fd_table()[fd].fs_fd   = -1;
+    current_fd_table()[fd].offset  = 0;
+    current_fd_table()[fd].path[0] = '\0';
     return fd;
 }
 
@@ -339,39 +348,62 @@ int vfs_socket_open(int socket_id) {
         return -1;
     }
 
-    fd_table[fd].used = 1;
-    fd_table[fd].fd_type = VFS_FD_TYPE_SOCKET;
-    fd_table[fd].pipe_is_write = 0;
-    fd_table[fd].fs_idx = -1;
-    fd_table[fd].fs_fd = socket_id;
-    fd_table[fd].offset = 0;
-    fd_table[fd].path[0] = '\0';
+    current_fd_table()[fd].used = 1;
+    current_fd_table()[fd].fd_type = VFS_FD_TYPE_SOCKET;
+    current_fd_table()[fd].pipe_is_write = 0;
+    current_fd_table()[fd].fs_idx = -1;
+    current_fd_table()[fd].fs_fd = socket_id;
+    current_fd_table()[fd].offset = 0;
+    current_fd_table()[fd].path[0] = '\0';
     return fd;
 }
 
 int vfs_fd_is_devev(int fd) {
-    if (fd < 0 || fd >= vfs_fd_capacity || !fd_table[fd].used) return 0;
-    return fd_table[fd].fd_type == VFS_FD_TYPE_DEVEV;
+    if (fd < 0 || fd >= current_fd_capacity() || !current_fd_table()[fd].used) return 0;
+    return current_fd_table()[fd].fd_type == VFS_FD_TYPE_DEVEV;
 }
 
 int vfs_fd_is_tty(int fd) {
-    if (fd < 0 || fd >= vfs_fd_capacity || !fd_table[fd].used) return 0;
-    return fd_table[fd].fd_type == VFS_FD_TYPE_TTY;
+    if (fd < 0 || fd >= current_fd_capacity() || !current_fd_table()[fd].used) return 0;
+    return current_fd_table()[fd].fd_type == VFS_FD_TYPE_TTY;
 }
 
 int vfs_fd_is_socket(int fd) {
-    if (fd < 0 || fd >= vfs_fd_capacity || !fd_table[fd].used) return 0;
-    return fd_table[fd].fd_type == VFS_FD_TYPE_SOCKET;
+    if (fd < 0 || fd >= current_fd_capacity() || !current_fd_table()[fd].used) return 0;
+    return current_fd_table()[fd].fd_type == VFS_FD_TYPE_SOCKET;
+}
+
+int vfs_fd_is_pipe(int fd) {
+    if (fd < 0 || fd >= current_fd_capacity() || !current_fd_table()[fd].used) return 0;
+    return current_fd_table()[fd].fd_type == VFS_FD_TYPE_PIPE;
+}
+
+/* Returns 1 if the pipe fd has data available to read (or EOF), 0 otherwise. */
+int vfs_pipe_readable(int fd) {
+    if (!vfs_fd_is_pipe(fd)) return 0;
+    int pipe_idx = current_fd_table()[fd].fs_fd;
+    if (pipe_idx < 0 || pipe_idx >= VFS_MAX_PIPES) return 0;
+    vfs_pipe_t *p = &pipe_pool[pipe_idx];
+    return (p->count > 0 || p->write_refcount == 0);
+}
+
+/* Returns 1 if the pipe fd has space to write, 0 otherwise. */
+int vfs_pipe_writable(int fd) {
+    if (!vfs_fd_is_pipe(fd)) return 0;
+    int pipe_idx = current_fd_table()[fd].fs_fd;
+    if (pipe_idx < 0 || pipe_idx >= VFS_MAX_PIPES) return 0;
+    vfs_pipe_t *p = &pipe_pool[pipe_idx];
+    return (p->count < VFS_PIPE_BUF_SIZE && p->read_refcount > 0);
 }
 
 int vfs_fd_is_open(int fd) {
-    if (fd < 0 || fd >= vfs_fd_capacity) return 0;
-    return fd_table[fd].used;
+    if (fd < 0 || fd >= current_fd_capacity()) return 0;
+    return current_fd_table()[fd].used;
 }
 
 int vfs_socket_id(int fd) {
     if (!vfs_fd_is_socket(fd)) return -1;
-    return fd_table[fd].fs_fd;
+    return current_fd_table()[fd].fs_fd;
 }
 
 int vfs_open(const char *path, int flags) {
@@ -386,14 +418,14 @@ int vfs_open(const char *path, int flags) {
     if (tty_kind != TTY_PATH_NONE) {
         fd = vfs_alloc_fd();
         if (fd < 0) return -1;
-        fd_table[fd].used = 1;
-        fd_table[fd].fd_type = VFS_FD_TYPE_TTY;
-        fd_table[fd].pipe_is_write = 0;
-        fd_table[fd].fs_idx = -1;
-        fd_table[fd].fs_fd = tty_kind;
-        fd_table[fd].offset = 0;
-        strncpy(fd_table[fd].path, path, VFS_PATH_LEN - 1);
-        fd_table[fd].path[VFS_PATH_LEN - 1] = '\0';
+        current_fd_table()[fd].used = 1;
+        current_fd_table()[fd].fd_type = VFS_FD_TYPE_TTY;
+        current_fd_table()[fd].pipe_is_write = 0;
+        current_fd_table()[fd].fs_idx = -1;
+        current_fd_table()[fd].fs_fd = tty_kind;
+        current_fd_table()[fd].offset = 0;
+        strncpy(current_fd_table()[fd].path, path, VFS_PATH_LEN - 1);
+        current_fd_table()[fd].path[VFS_PATH_LEN - 1] = '\0';
         return fd;
     }
 
@@ -440,16 +472,16 @@ int vfs_open(const char *path, int flags) {
             int fd = vfs_alloc_fd();
             if (fd < 0) { kprintf("[VFS]  Out of file descriptors for %s!\n", path); return -1; }
 
-            fd_table[fd].used    = 1;
-            fd_table[fd].fd_type = VFS_FD_TYPE_FILE; /* directory represented as file FD */
-            fd_table[fd].fs_fd   = -1; /* no per-FS handle */
-            fd_table[fd].offset  = 0;
-            fd_table[fd].fs_idx  = -1; /* initialise before scan */
-            strncpy(fd_table[fd].path, path, VFS_PATH_LEN - 1);
-            fd_table[fd].path[VFS_PATH_LEN - 1] = '\0';
+            current_fd_table()[fd].used    = 1;
+            current_fd_table()[fd].fd_type = VFS_FD_TYPE_FILE; /* directory represented as file FD */
+            current_fd_table()[fd].fs_fd   = -1; /* no per-FS handle */
+            current_fd_table()[fd].offset  = 0;
+            current_fd_table()[fd].fs_idx  = -1; /* initialise before scan */
+            strncpy(current_fd_table()[fd].path, path, VFS_PATH_LEN - 1);
+            current_fd_table()[fd].path[VFS_PATH_LEN - 1] = '\0';
             // find mount index
             for (int i = 0; i < mount_count; i++) {
-                if (&mounts[i] == m) { fd_table[fd].fs_idx = i; break; }
+                if (&mounts[i] == m) { current_fd_table()[fd].fs_idx = i; break; }
             }
             return fd;
         }
@@ -477,28 +509,28 @@ int vfs_open(const char *path, int flags) {
         return -1;
     }
 
-    fd_table[fd].used    = 1;
-    fd_table[fd].fd_type = VFS_FD_TYPE_FILE;
-    fd_table[fd].fs_fd   = fs_fd;
-    fd_table[fd].offset  = 0;
-    strncpy(fd_table[fd].path, path, VFS_PATH_LEN - 1);
+    current_fd_table()[fd].used    = 1;
+    current_fd_table()[fd].fd_type = VFS_FD_TYPE_FILE;
+    current_fd_table()[fd].fs_fd   = fs_fd;
+    current_fd_table()[fd].offset  = 0;
+    strncpy(current_fd_table()[fd].path, path, VFS_PATH_LEN - 1);
     // find mount index
     for (int i = 0; i < mount_count; i++) {
-        if (&mounts[i] == m) { fd_table[fd].fs_idx = i; break; }
+        if (&mounts[i] == m) { current_fd_table()[fd].fs_idx = i; break; }
     }
     return fd;
 }
 
 int vfs_read(int fd, uint8_t *buf, size_t len) {
-    if (fd < 0 || fd >= vfs_fd_capacity || !fd_table[fd].used) return -1;
-    if (fd_table[fd].fd_type == VFS_FD_TYPE_DEVEV)
+    if (fd < 0 || fd >= current_fd_capacity() || !current_fd_table()[fd].used) return -1;
+    if (current_fd_table()[fd].fd_type == VFS_FD_TYPE_DEVEV)
         return devev_read_bytes(buf, len);
-    if (fd_table[fd].fd_type == VFS_FD_TYPE_SOCKET)
-        return socket_read(fd_table[fd].fs_fd, buf, len);
-    if (fd_table[fd].fd_type == VFS_FD_TYPE_TTY)
+    if (current_fd_table()[fd].fd_type == VFS_FD_TYPE_SOCKET)
+        return socket_read(current_fd_table()[fd].fs_fd, buf, len);
+    if (current_fd_table()[fd].fd_type == VFS_FD_TYPE_TTY)
         return tty_read((char*)buf, len);
-    if (fd_table[fd].fd_type == VFS_FD_TYPE_PIPE) {
-        int pipe_idx = fd_table[fd].fs_fd;
+    if (current_fd_table()[fd].fd_type == VFS_FD_TYPE_PIPE) {
+        int pipe_idx = current_fd_table()[fd].fs_fd;
         if (pipe_idx < 0 || pipe_idx >= VFS_MAX_PIPES) return -1;
         vfs_pipe_t *p = &pipe_pool[pipe_idx];
         size_t avail = p->count < len ? p->count : len;
@@ -515,45 +547,45 @@ int vfs_read(int fd, uint8_t *buf, size_t len) {
         p->count -= (uint32_t)avail;
         return (int)avail;
     }
-    vfs_mount_t *m = &mounts[fd_table[fd].fs_idx];
+    vfs_mount_t *m = &mounts[current_fd_table()[fd].fs_idx];
     if (!m->fs->read_at) {
         if (!m->fs->read) return -1;
-        int r = m->fs->read(fd_table[fd].fs_fd, buf, len);
-        if (r > 0) fd_table[fd].offset += (uint32_t)r;
+        int r = m->fs->read(current_fd_table()[fd].fs_fd, buf, len);
+        if (r > 0) current_fd_table()[fd].offset += (uint32_t)r;
         return r;
     }
-    int r = m->fs->read_at(fd_table[fd].fs_fd, buf, len, fd_table[fd].offset);
-    if (r > 0) fd_table[fd].offset += (uint32_t)r;
+    int r = m->fs->read_at(current_fd_table()[fd].fs_fd, buf, len, current_fd_table()[fd].offset);
+    if (r > 0) current_fd_table()[fd].offset += (uint32_t)r;
     return r;
 }
 
 int vfs_read_at(int fd, uint8_t *buf, size_t len, uint32_t offset) {
-    if (fd < 0 || fd >= vfs_fd_capacity || !fd_table[fd].used) return -1;
-    if (fd_table[fd].fd_type == VFS_FD_TYPE_DEVEV) return -1;
-    if (fd_table[fd].fd_type == VFS_FD_TYPE_SOCKET) return -1;
-    if (fd_table[fd].fd_type == VFS_FD_TYPE_TTY) return -1;
-    if (fd_table[fd].fd_type == VFS_FD_TYPE_PIPE) return -1;
-    vfs_mount_t *m = &mounts[fd_table[fd].fs_idx];
+    if (fd < 0 || fd >= current_fd_capacity() || !current_fd_table()[fd].used) return -1;
+    if (current_fd_table()[fd].fd_type == VFS_FD_TYPE_DEVEV) return -1;
+    if (current_fd_table()[fd].fd_type == VFS_FD_TYPE_SOCKET) return -1;
+    if (current_fd_table()[fd].fd_type == VFS_FD_TYPE_TTY) return -1;
+    if (current_fd_table()[fd].fd_type == VFS_FD_TYPE_PIPE) return -1;
+    vfs_mount_t *m = &mounts[current_fd_table()[fd].fs_idx];
     if (!m->fs->read_at) {
         /* Fallback: try to emulate by reading from current offset (best-effort) */
         if (!m->fs->read) return -1;
         return -1; /* explicit failure to avoid surprising side-effects */
     }
-    return m->fs->read_at(fd_table[fd].fs_fd, buf, len, offset);
+    return m->fs->read_at(current_fd_table()[fd].fs_fd, buf, len, offset);
 }
 
 int vfs_write(int fd, const uint8_t *buf, size_t len) {
-    if (fd < 0 || fd >= vfs_fd_capacity || !fd_table[fd].used) return -1;
-    if (fd_table[fd].fd_type == VFS_FD_TYPE_SOCKET) {
-        return socket_write(fd_table[fd].fs_fd, buf, len);
+    if (fd < 0 || fd >= current_fd_capacity() || !current_fd_table()[fd].used) return -1;
+    if (current_fd_table()[fd].fd_type == VFS_FD_TYPE_SOCKET) {
+        return socket_write(current_fd_table()[fd].fs_fd, buf, len);
     }
-    if (fd_table[fd].fd_type == VFS_FD_TYPE_TTY) {
+    if (current_fd_table()[fd].fd_type == VFS_FD_TYPE_TTY) {
         tty_write((const char*)buf, len);
         tty_flush();
         return (int)len;
     }
-    if (fd_table[fd].fd_type == VFS_FD_TYPE_PIPE) {
-        int pipe_idx = fd_table[fd].fs_fd;
+    if (current_fd_table()[fd].fd_type == VFS_FD_TYPE_PIPE) {
+        int pipe_idx = current_fd_table()[fd].fs_fd;
         if (pipe_idx < 0 || pipe_idx >= VFS_MAX_PIPES) return -1;
         vfs_pipe_t *p = &pipe_pool[pipe_idx];
         size_t space = VFS_PIPE_BUF_SIZE - p->count;
@@ -565,8 +597,8 @@ int vfs_write(int fd, const uint8_t *buf, size_t len) {
         p->count += (uint32_t)towrite;
         return (int)towrite;
     }
-    if (fd_table[fd].fd_type == VFS_FD_TYPE_DEVEV) return -1;
-    vfs_mount_t *m = &mounts[fd_table[fd].fs_idx];
+    if (current_fd_table()[fd].fd_type == VFS_FD_TYPE_DEVEV) return -1;
+    vfs_mount_t *m = &mounts[current_fd_table()[fd].fs_idx];
     if (!m->fs->write) return -1;
 #ifdef DEBUG
     /* Lightweight instrumentation: record the caller of vfs_write so we can
@@ -577,23 +609,23 @@ int vfs_write(int fd, const uint8_t *buf, size_t len) {
     kprintf("[VFS DBG] vfs_write caller=%p fd=%d len=%u\n", caller, fd, (unsigned)len);
 #endif
 
-    int r = m->fs->write(fd_table[fd].fs_fd, buf, len);
-    if (r > 0) fd_table[fd].offset += (uint32_t)r;
+    int r = m->fs->write(current_fd_table()[fd].fs_fd, buf, len);
+    if (r > 0) current_fd_table()[fd].offset += (uint32_t)r;
     return r;
 }
 
 int vfs_close(int fd) {
-    if (fd < 0 || fd >= vfs_fd_capacity || !fd_table[fd].used) return -1;
-    if (fd_table[fd].fd_type == VFS_FD_TYPE_FILE) {
-        vfs_mount_t *m = &mounts[fd_table[fd].fs_idx];
-        if (m->fs->close) m->fs->close(fd_table[fd].fs_fd);
-    } else if (fd_table[fd].fd_type == VFS_FD_TYPE_SOCKET) {
-        socket_close(fd_table[fd].fs_fd);
-    } else if (fd_table[fd].fd_type == VFS_FD_TYPE_PIPE) {
-        int pipe_idx = fd_table[fd].fs_fd;
+    if (fd < 0 || fd >= current_fd_capacity() || !current_fd_table()[fd].used) return -1;
+    if (current_fd_table()[fd].fd_type == VFS_FD_TYPE_FILE) {
+        vfs_mount_t *m = &mounts[current_fd_table()[fd].fs_idx];
+        if (m->fs->close) m->fs->close(current_fd_table()[fd].fs_fd);
+    } else if (current_fd_table()[fd].fd_type == VFS_FD_TYPE_SOCKET) {
+        socket_close(current_fd_table()[fd].fs_fd);
+    } else if (current_fd_table()[fd].fd_type == VFS_FD_TYPE_PIPE) {
+        int pipe_idx = current_fd_table()[fd].fs_fd;
         if (pipe_idx >= 0 && pipe_idx < VFS_MAX_PIPES) {
             vfs_pipe_t *p = &pipe_pool[pipe_idx];
-            if (fd_table[fd].pipe_is_write) {
+            if (current_fd_table()[fd].pipe_is_write) {
                 if (p->write_refcount > 0) p->write_refcount--;
             } else {
                 if (p->read_refcount > 0) p->read_refcount--;
@@ -601,20 +633,20 @@ int vfs_close(int fd) {
             if (p->read_refcount == 0 && p->write_refcount == 0) p->used = 0;
         }
     }
-    fd_table[fd].used = 0;
+    current_fd_table()[fd].used = 0;
     return 0;
 }
 
 int32_t vfs_lseek(int fd, int32_t offset, int whence) {
-    if (fd < 0 || fd >= vfs_fd_capacity || !fd_table[fd].used) return -1;
-    if (fd_table[fd].fd_type != VFS_FD_TYPE_FILE) return -1;
+    if (fd < 0 || fd >= current_fd_capacity() || !current_fd_table()[fd].used) return -1;
+    if (current_fd_table()[fd].fd_type != VFS_FD_TYPE_FILE) return -1;
 
     uint32_t new_offset;
     if (whence == VFS_SEEK_SET) {
         if (offset < 0) return -1;
         new_offset = (uint32_t)offset;
     } else if (whence == VFS_SEEK_CUR) {
-        int32_t cur = (int32_t)fd_table[fd].offset;
+        int32_t cur = (int32_t)current_fd_table()[fd].offset;
         int32_t result = cur + offset;
         if (result < 0) return -1; /* would underflow */
         new_offset = (uint32_t)result;
@@ -628,26 +660,26 @@ int32_t vfs_lseek(int fd, int32_t offset, int whence) {
     } else {
         return -1;
     }
-    fd_table[fd].offset = new_offset;
+    current_fd_table()[fd].offset = new_offset;
     return (int32_t)new_offset;
 }
 
 int vfs_dup(int oldfd) {
-    if (oldfd < 0 || oldfd >= vfs_fd_capacity || !fd_table[oldfd].used) {
+    if (oldfd < 0 || oldfd >= current_fd_capacity() || !current_fd_table()[oldfd].used) {
         vfs_set_last_error(VFS_ERR_EBADF);
         return -1;
     }
     int newfd = vfs_alloc_fd();
     if (newfd < 0) return -1;
-    fd_table[newfd] = fd_table[oldfd];
-    if (fd_table[newfd].fd_type == VFS_FD_TYPE_SOCKET) {
-        socket_add_ref(fd_table[newfd].fs_fd);
+    current_fd_table()[newfd] = current_fd_table()[oldfd];
+    if (current_fd_table()[newfd].fd_type == VFS_FD_TYPE_SOCKET) {
+        socket_add_ref(current_fd_table()[newfd].fs_fd);
     }
     /* For pipes, increment the appropriate reference count */
-    if (fd_table[newfd].fd_type == VFS_FD_TYPE_PIPE) {
-        int pipe_idx = fd_table[newfd].fs_fd;
+    if (current_fd_table()[newfd].fd_type == VFS_FD_TYPE_PIPE) {
+        int pipe_idx = current_fd_table()[newfd].fs_fd;
         if (pipe_idx >= 0 && pipe_idx < VFS_MAX_PIPES) {
-            if (fd_table[newfd].pipe_is_write)
+            if (current_fd_table()[newfd].pipe_is_write)
                 pipe_pool[pipe_idx].write_refcount++;
             else
                 pipe_pool[pipe_idx].read_refcount++;
@@ -660,7 +692,7 @@ int vfs_dup(int oldfd) {
 int vfs_dup2(int oldfd, int newfd) {
     int limit = vfs_effective_fd_limit();
 
-    if (oldfd < 0 || oldfd >= vfs_fd_capacity || !fd_table[oldfd].used) {
+    if (oldfd < 0 || oldfd >= current_fd_capacity() || !current_fd_table()[oldfd].used) {
         vfs_set_last_error(VFS_ERR_EBADF);
         return -1;
     }
@@ -668,21 +700,21 @@ int vfs_dup2(int oldfd, int newfd) {
         vfs_set_last_error(VFS_ERR_EBADF);
         return -1;
     }
-    if (newfd >= vfs_fd_capacity && !vfs_grow_fd_capacity(newfd + 1)) {
+    if (newfd >= current_fd_capacity() && !vfs_grow_fd_capacity(newfd + 1)) {
         vfs_set_last_error(VFS_ERR_ENFILE);
         return -1;
     }
     if (oldfd == newfd) return newfd;
-    if (fd_table[newfd].used) vfs_close(newfd);
-    fd_table[newfd] = fd_table[oldfd];
-    if (fd_table[newfd].fd_type == VFS_FD_TYPE_SOCKET) {
-        socket_add_ref(fd_table[newfd].fs_fd);
+    if (current_fd_table()[newfd].used) vfs_close(newfd);
+    current_fd_table()[newfd] = current_fd_table()[oldfd];
+    if (current_fd_table()[newfd].fd_type == VFS_FD_TYPE_SOCKET) {
+        socket_add_ref(current_fd_table()[newfd].fs_fd);
     }
     /* For pipes, increment the appropriate reference count */
-    if (fd_table[newfd].fd_type == VFS_FD_TYPE_PIPE) {
-        int pipe_idx = fd_table[newfd].fs_fd;
+    if (current_fd_table()[newfd].fd_type == VFS_FD_TYPE_PIPE) {
+        int pipe_idx = current_fd_table()[newfd].fs_fd;
         if (pipe_idx >= 0 && pipe_idx < VFS_MAX_PIPES) {
-            if (fd_table[newfd].pipe_is_write)
+            if (current_fd_table()[newfd].pipe_is_write)
                 pipe_pool[pipe_idx].write_refcount++;
             else
                 pipe_pool[pipe_idx].read_refcount++;
@@ -705,29 +737,29 @@ int vfs_pipe(int fds[2]) {
     if (rfd < 0) { pipe_pool[pipe_idx].used = 0; return -1; }
 
     /* Temporarily mark rfd used so vfs_alloc_fd skips it for wfd */
-    fd_table[rfd].used = 1;
+    current_fd_table()[rfd].used = 1;
     int wfd = vfs_alloc_fd();
     if (wfd < 0) {
-        fd_table[rfd].used = 0;
+        current_fd_table()[rfd].used = 0;
         pipe_pool[pipe_idx].used = 0;
         return -1;
     }
 
-    fd_table[rfd].used         = 1;
-    fd_table[rfd].fd_type      = VFS_FD_TYPE_PIPE;
-    fd_table[rfd].pipe_is_write = 0;
-    fd_table[rfd].fs_fd        = pipe_idx;
-    fd_table[rfd].fs_idx       = -1;
-    fd_table[rfd].offset       = 0;
-    fd_table[rfd].path[0]      = '\0';
+    current_fd_table()[rfd].used         = 1;
+    current_fd_table()[rfd].fd_type      = VFS_FD_TYPE_PIPE;
+    current_fd_table()[rfd].pipe_is_write = 0;
+    current_fd_table()[rfd].fs_fd        = pipe_idx;
+    current_fd_table()[rfd].fs_idx       = -1;
+    current_fd_table()[rfd].offset       = 0;
+    current_fd_table()[rfd].path[0]      = '\0';
 
-    fd_table[wfd].used         = 1;
-    fd_table[wfd].fd_type      = VFS_FD_TYPE_PIPE;
-    fd_table[wfd].pipe_is_write = 1;
-    fd_table[wfd].fs_fd        = pipe_idx;
-    fd_table[wfd].fs_idx       = -1;
-    fd_table[wfd].offset       = 0;
-    fd_table[wfd].path[0]      = '\0';
+    current_fd_table()[wfd].used         = 1;
+    current_fd_table()[wfd].fd_type      = VFS_FD_TYPE_PIPE;
+    current_fd_table()[wfd].pipe_is_write = 1;
+    current_fd_table()[wfd].fs_fd        = pipe_idx;
+    current_fd_table()[wfd].fs_idx       = -1;
+    current_fd_table()[wfd].offset       = 0;
+    current_fd_table()[wfd].path[0]      = '\0';
 
     pipe_pool[pipe_idx].read_refcount  = 1;
     pipe_pool[pipe_idx].write_refcount = 1;
@@ -739,16 +771,16 @@ int vfs_pipe(int fds[2]) {
 }
 
 const char *vfs_fd_get_path(int fd) {
-    if (fd < 0 || fd >= vfs_fd_capacity || !fd_table[fd].used) return NULL;
-    if (fd_table[fd].fd_type != VFS_FD_TYPE_FILE) return NULL;
-    return fd_table[fd].path;
+    if (fd < 0 || fd >= current_fd_capacity() || !current_fd_table()[fd].used) return NULL;
+    if (current_fd_table()[fd].fd_type != VFS_FD_TYPE_FILE) return NULL;
+    return current_fd_table()[fd].path;
 }
 
 /* Allocate the lowest free fd >= min_fd; used for F_DUPFD semantics */
 int vfs_dup_above(int oldfd, int min_fd) {
     int limit = vfs_effective_fd_limit();
 
-    if (oldfd < 0 || oldfd >= vfs_fd_capacity || !fd_table[oldfd].used) {
+    if (oldfd < 0 || oldfd >= current_fd_capacity() || !current_fd_table()[oldfd].used) {
         vfs_set_last_error(VFS_ERR_EBADF);
         return -1;
     }
@@ -756,18 +788,18 @@ int vfs_dup_above(int oldfd, int min_fd) {
         vfs_set_last_error(VFS_ERR_EMFILE);
         return -1;
     }
-    if (limit > vfs_fd_capacity) vfs_grow_fd_capacity(limit);
+    if (limit > current_fd_capacity()) vfs_grow_fd_capacity(limit);
 
-    for (int i = min_fd; i < limit && i < vfs_fd_capacity; i++) {
-        if (!fd_table[i].used) {
-            fd_table[i] = fd_table[oldfd];
-            if (fd_table[i].fd_type == VFS_FD_TYPE_SOCKET) {
-                socket_add_ref(fd_table[i].fs_fd);
+    for (int i = min_fd; i < limit && i < current_fd_capacity(); i++) {
+        if (!current_fd_table()[i].used) {
+            current_fd_table()[i] = current_fd_table()[oldfd];
+            if (current_fd_table()[i].fd_type == VFS_FD_TYPE_SOCKET) {
+                socket_add_ref(current_fd_table()[i].fs_fd);
             }
-            if (fd_table[i].fd_type == VFS_FD_TYPE_PIPE) {
-                int pipe_idx = fd_table[i].fs_fd;
+            if (current_fd_table()[i].fd_type == VFS_FD_TYPE_PIPE) {
+                int pipe_idx = current_fd_table()[i].fs_fd;
                 if (pipe_idx >= 0 && pipe_idx < VFS_MAX_PIPES) {
-                    if (fd_table[i].pipe_is_write)
+                    if (current_fd_table()[i].pipe_is_write)
                         pipe_pool[pipe_idx].write_refcount++;
                     else
                         pipe_pool[pipe_idx].read_refcount++;
@@ -902,10 +934,10 @@ int vfs_stat(const char *path, vfs_stat_t *out) {
 }
 
 int vfs_fstat(int fd, vfs_stat_t *out) {
-    if (fd < 0 || fd >= vfs_fd_capacity) return -1;
-    if (!fd_table[fd].used) return -1;
+    if (fd < 0 || fd >= current_fd_capacity()) return -1;
+    if (!current_fd_table()[fd].used) return -1;
     if (!out) return -1;
-    if (fd_table[fd].fd_type == VFS_FD_TYPE_SOCKET) {
+    if (current_fd_table()[fd].fd_type == VFS_FD_TYPE_SOCKET) {
         out->mode = VFS_S_IFCHR | VFS_S_IRUSR | VFS_S_IWUSR;
         out->uid = 0;
         out->gid = 0;
@@ -913,7 +945,7 @@ int vfs_fstat(int fd, vfs_stat_t *out) {
         out->is_dir = 0;
         return 0;
     }
-    if (fd_table[fd].fd_type == VFS_FD_TYPE_TTY) {
+    if (current_fd_table()[fd].fd_type == VFS_FD_TYPE_TTY) {
         out->mode = VFS_S_IFCHR | VFS_S_IRUSR | VFS_S_IWUSR |
                     VFS_S_IRGRP | VFS_S_IWGRP |
                     VFS_S_IROTH | VFS_S_IWOTH;
@@ -923,7 +955,7 @@ int vfs_fstat(int fd, vfs_stat_t *out) {
         out->is_dir = 0;
         return 0;
     }
-    return vfs_stat(fd_table[fd].path, out);
+    return vfs_stat(current_fd_table()[fd].path, out);
 }
 
 int vfs_access(const char *path, uint8_t access) {
@@ -988,8 +1020,8 @@ int vfs_chmod(const char *path, uint16_t mode) {
 }
 
 int vfs_fchmod(int fd, uint16_t mode) {
-    if (fd < 0 || fd >= vfs_fd_capacity || !fd_table[fd].used) return -1;
-    const char *path = fd_table[fd].path;
+    if (fd < 0 || fd >= current_fd_capacity() || !current_fd_table()[fd].used) return -1;
+    const char *path = current_fd_table()[fd].path;
     if (!path || !path[0]) return -1;
     return vfs_chmod(path, mode);
 }
@@ -1016,8 +1048,8 @@ int vfs_lchown(const char *path, uint32_t uid, uint32_t gid) {
 }
 
 int vfs_fchown(int fd, uint32_t uid, uint32_t gid) {
-    if (fd < 0 || fd >= vfs_fd_capacity || !fd_table[fd].used) return -1;
-    const char *path = fd_table[fd].path;
+    if (fd < 0 || fd >= current_fd_capacity() || !current_fd_table()[fd].used) return -1;
+    const char *path = current_fd_table()[fd].path;
     if (!path || !path[0]) return -1;
     return vfs_chown(path, uid, gid);
 }
@@ -1030,4 +1062,59 @@ void vfs_print_mounts(void) {
                     mounts[i].mountpoint, mounts[i].fs->name, mounts[i].start_lba);
     }
     if (!mount_count) kprintf("  (none)\n");
+}
+
+/*
+ * Copy the parent's fd table into the child's and increment refcounts for
+ * any inherited pipe/socket fds.  Called from process_fork_current().
+ */
+void vfs_inherit_fd_table(process_t *parent, process_t *child) {
+    memcpy(child->fd_table, parent->fd_table, sizeof(child->fd_table));
+    for (int i = 0; i < VFS_MAX_OPEN; i++) {
+        if (!child->fd_table[i].used) continue;
+        if (child->fd_table[i].fd_type == VFS_FD_TYPE_PIPE) {
+            int idx = child->fd_table[i].fs_fd;
+            if (idx >= 0 && idx < VFS_MAX_PIPES) {
+                if (child->fd_table[i].pipe_is_write)
+                    pipe_pool[idx].write_refcount++;
+                else
+                    pipe_pool[idx].read_refcount++;
+            }
+        }
+        if (child->fd_table[i].fd_type == VFS_FD_TYPE_SOCKET) {
+            socket_add_ref(child->fd_table[i].fs_fd);
+        }
+    }
+}
+
+/*
+ * Close all open fds in the given process's table, decrementing pipe/socket
+ * refcounts.  Must operate on the explicit process table — NOT current_fd_table()
+ * — because this may be called on a non-current process (e.g. clone failure).
+ */
+void vfs_close_all_fds_for_process(process_t *p) {
+    vfs_fd_t *table = p->fd_table;
+    for (int i = 0; i < VFS_MAX_OPEN; i++) {
+        if (!table[i].used) continue;
+        if (table[i].fd_type == VFS_FD_TYPE_FILE) {
+            if (table[i].fs_idx >= 0 && table[i].fs_idx < VFS_MAX_MOUNTS) {
+                vfs_mount_t *m = &mounts[table[i].fs_idx];
+                if (m->fs && m->fs->close) m->fs->close(table[i].fs_fd);
+            }
+        } else if (table[i].fd_type == VFS_FD_TYPE_PIPE) {
+            int pipe_idx = table[i].fs_fd;
+            if (pipe_idx >= 0 && pipe_idx < VFS_MAX_PIPES) {
+                vfs_pipe_t *pp = &pipe_pool[pipe_idx];
+                if (table[i].pipe_is_write) {
+                    if (pp->write_refcount > 0) pp->write_refcount--;
+                } else {
+                    if (pp->read_refcount > 0) pp->read_refcount--;
+                }
+                if (pp->read_refcount == 0 && pp->write_refcount == 0) pp->used = 0;
+            }
+        } else if (table[i].fd_type == VFS_FD_TYPE_SOCKET) {
+            socket_close(table[i].fs_fd);
+        }
+        table[i].used = 0;
+    }
 }

--- a/fs/vfs.c
+++ b/fs/vfs.c
@@ -299,11 +299,6 @@ static vfs_mount_t *vfs_find_mount(const char *path) {
             best_len = mlen;
         }
     }
-    if (path && path[1] == 'd' && path[2] == 'e' && path[3] == 'v' && path[4] == '/') {
-        kprintf("[MOUNT_DBG] path=%s mount_count=%d best=%p mp=%s\n",
-                path, mount_count, (void*)best,
-                best ? best->mountpoint : "(none)");
-    }
     return best;
 }
 
@@ -958,16 +953,8 @@ int vfs_unlink(const char *path) {
 
 int vfs_stat(const char *path, vfs_stat_t *out) {
     vfs_mount_t *m = vfs_find_mount(path);
-    if (path && path[1] == 'd' && path[2] == 'e' && path[3] == 'v' && path[4] == '/') {
-        kprintf("[VFS_STAT_DBG] path=%s m=%p stat_cb=%p\n",
-                path, (void*)m, m ? (void*)m->fs->stat : (void*)0);
-    }
     if (!m || !m->fs->stat) return -1;
-    int rc = m->fs->stat(path, out);
-    if (path && path[1] == 'd' && path[2] == 'e' && path[3] == 'v' && path[4] == '/') {
-        kprintf("[VFS_STAT_DBG] stat_cb rc=%d\n", rc);
-    }
-    return rc;
+    return m->fs->stat(path, out);
 }
 
 int vfs_fstat(int fd, vfs_stat_t *out) {
@@ -1114,8 +1101,6 @@ void vfs_inherit_fd_table(process_t *parent, process_t *child) {
             if (fs_idx >= 0 && fs_idx < VFS_MAX_MOUNTS) {
                 vfs_mount_t *m = &mounts[fs_idx];
                 if (m->fs && m->fs->addref) {
-                    kprintf("[VFS] inherit fd=%d slot=%d: addref (child pid=%u)\n",
-                            i, child->fd_table[i].fs_fd, child->pid);
                     m->fs->addref(child->fd_table[i].fs_fd);
                 }
             }

--- a/fs/vfs.c
+++ b/fs/vfs.c
@@ -299,6 +299,11 @@ static vfs_mount_t *vfs_find_mount(const char *path) {
             best_len = mlen;
         }
     }
+    if (path && path[1] == 'd' && path[2] == 'e' && path[3] == 'v' && path[4] == '/') {
+        kprintf("[MOUNT_DBG] path=%s mount_count=%d best=%p mp=%s\n",
+                path, mount_count, (void*)best,
+                best ? best->mountpoint : "(none)");
+    }
     return best;
 }
 
@@ -617,8 +622,11 @@ int vfs_write(int fd, const uint8_t *buf, size_t len) {
 int vfs_close(int fd) {
     if (fd < 0 || fd >= current_fd_capacity() || !current_fd_table()[fd].used) return -1;
     if (current_fd_table()[fd].fd_type == VFS_FD_TYPE_FILE) {
-        vfs_mount_t *m = &mounts[current_fd_table()[fd].fs_idx];
-        if (m->fs->close) m->fs->close(current_fd_table()[fd].fs_fd);
+        int fs_idx = current_fd_table()[fd].fs_idx;
+        if (fs_idx >= 0) {
+            vfs_mount_t *m = &mounts[fs_idx];
+            if (m->fs->close) m->fs->close(current_fd_table()[fd].fs_fd);
+        }
     } else if (current_fd_table()[fd].fd_type == VFS_FD_TYPE_SOCKET) {
         socket_close(current_fd_table()[fd].fs_fd);
     } else if (current_fd_table()[fd].fd_type == VFS_FD_TYPE_PIPE) {
@@ -672,6 +680,13 @@ int vfs_dup(int oldfd) {
     int newfd = vfs_alloc_fd();
     if (newfd < 0) return -1;
     current_fd_table()[newfd] = current_fd_table()[oldfd];
+    if (current_fd_table()[newfd].fd_type == VFS_FD_TYPE_FILE) {
+        int fs_idx = current_fd_table()[newfd].fs_idx;
+        if (fs_idx >= 0 && fs_idx < VFS_MAX_MOUNTS) {
+            vfs_mount_t *m = &mounts[fs_idx];
+            if (m->fs && m->fs->addref) m->fs->addref(current_fd_table()[newfd].fs_fd);
+        }
+    }
     if (current_fd_table()[newfd].fd_type == VFS_FD_TYPE_SOCKET) {
         socket_add_ref(current_fd_table()[newfd].fs_fd);
     }
@@ -707,6 +722,13 @@ int vfs_dup2(int oldfd, int newfd) {
     if (oldfd == newfd) return newfd;
     if (current_fd_table()[newfd].used) vfs_close(newfd);
     current_fd_table()[newfd] = current_fd_table()[oldfd];
+    if (current_fd_table()[newfd].fd_type == VFS_FD_TYPE_FILE) {
+        int fs_idx = current_fd_table()[newfd].fs_idx;
+        if (fs_idx >= 0 && fs_idx < VFS_MAX_MOUNTS) {
+            vfs_mount_t *m = &mounts[fs_idx];
+            if (m->fs && m->fs->addref) m->fs->addref(current_fd_table()[newfd].fs_fd);
+        }
+    }
     if (current_fd_table()[newfd].fd_type == VFS_FD_TYPE_SOCKET) {
         socket_add_ref(current_fd_table()[newfd].fs_fd);
     }
@@ -793,6 +815,13 @@ int vfs_dup_above(int oldfd, int min_fd) {
     for (int i = min_fd; i < limit && i < current_fd_capacity(); i++) {
         if (!current_fd_table()[i].used) {
             current_fd_table()[i] = current_fd_table()[oldfd];
+            if (current_fd_table()[i].fd_type == VFS_FD_TYPE_FILE) {
+                int fs_idx = current_fd_table()[i].fs_idx;
+                if (fs_idx >= 0 && fs_idx < VFS_MAX_MOUNTS) {
+                    vfs_mount_t *m = &mounts[fs_idx];
+                    if (m->fs && m->fs->addref) m->fs->addref(current_fd_table()[i].fs_fd);
+                }
+            }
             if (current_fd_table()[i].fd_type == VFS_FD_TYPE_SOCKET) {
                 socket_add_ref(current_fd_table()[i].fs_fd);
             }
@@ -929,8 +958,16 @@ int vfs_unlink(const char *path) {
 
 int vfs_stat(const char *path, vfs_stat_t *out) {
     vfs_mount_t *m = vfs_find_mount(path);
+    if (path && path[1] == 'd' && path[2] == 'e' && path[3] == 'v' && path[4] == '/') {
+        kprintf("[VFS_STAT_DBG] path=%s m=%p stat_cb=%p\n",
+                path, (void*)m, m ? (void*)m->fs->stat : (void*)0);
+    }
     if (!m || !m->fs->stat) return -1;
-    return m->fs->stat(path, out);
+    int rc = m->fs->stat(path, out);
+    if (path && path[1] == 'd' && path[2] == 'e' && path[3] == 'v' && path[4] == '/') {
+        kprintf("[VFS_STAT_DBG] stat_cb rc=%d\n", rc);
+    }
+    return rc;
 }
 
 int vfs_fstat(int fd, vfs_stat_t *out) {
@@ -1072,6 +1109,17 @@ void vfs_inherit_fd_table(process_t *parent, process_t *child) {
     memcpy(child->fd_table, parent->fd_table, sizeof(child->fd_table));
     for (int i = 0; i < VFS_MAX_OPEN; i++) {
         if (!child->fd_table[i].used) continue;
+        if (child->fd_table[i].fd_type == VFS_FD_TYPE_FILE) {
+            int fs_idx = child->fd_table[i].fs_idx;
+            if (fs_idx >= 0 && fs_idx < VFS_MAX_MOUNTS) {
+                vfs_mount_t *m = &mounts[fs_idx];
+                if (m->fs && m->fs->addref) {
+                    kprintf("[VFS] inherit fd=%d slot=%d: addref (child pid=%u)\n",
+                            i, child->fd_table[i].fs_fd, child->pid);
+                    m->fs->addref(child->fd_table[i].fs_fd);
+                }
+            }
+        }
         if (child->fd_table[i].fd_type == VFS_FD_TYPE_PIPE) {
             int idx = child->fd_table[i].fs_fd;
             if (idx >= 0 && idx < VFS_MAX_PIPES) {

--- a/fs/vfs.h
+++ b/fs/vfs.h
@@ -107,10 +107,25 @@ typedef struct {
 #define VFS_FD_TYPE_TTY   3   // kernel console/tty device
 #define VFS_FD_TYPE_SOCKET 4  // in-kernel local socket endpoint
 
+// Per-process file descriptor entry (one slot in a process's fd table)
+typedef struct {
+    int      used;
+    int      fs_idx;        // which mount point (-1 for non-file types)
+    int      fs_fd;         // fd returned by underlying fs, pipe index, or socket id
+    char     path[VFS_PATH_LEN];
+    uint8_t  fd_type;       // VFS_FD_TYPE_*
+    uint8_t  pipe_is_write; // 1 = write end of a pipe, 0 = read end
+    uint32_t offset;        // current seek position
+} vfs_fd_t;
+
 // lseek whence values (POSIX-compatible)
 #define VFS_SEEK_SET 0
 #define VFS_SEEK_CUR 1
 #define VFS_SEEK_END 2
+
+/* Forward declaration so vfs_inherit_fd_table / vfs_close_all_fds_for_process
+ * can take process_t * without creating a circular header dependency. */
+struct process;
 
 void vfs_init(void);
 void vfs_register_fs(filesystem_t *fs);
@@ -122,6 +137,9 @@ int  vfs_socket_open(int socket_id); // attach a kernel socket to a VFS fd
 int  vfs_fd_is_devev(int fd);        // 1 if the fd is a device event channel
 int  vfs_fd_is_tty(int fd);          // 1 if the fd is a tty/console device
 int  vfs_fd_is_socket(int fd);       // 1 if the fd is a socket endpoint
+int  vfs_fd_is_pipe(int fd);         // 1 if the fd is a pipe
+int  vfs_pipe_readable(int fd);      // 1 if pipe has data (or EOF)
+int  vfs_pipe_writable(int fd);      // 1 if pipe has write space
 int  vfs_fd_is_open(int fd);         // 1 if descriptor exists and is open
 int  vfs_socket_id(int fd);          // backend socket id for a socket fd
 int  vfs_get_last_error(void);       // last VFS fd-allocation related errno code
@@ -152,3 +170,7 @@ int  vfs_chown(const char *path, uint32_t uid, uint32_t gid);
 int  vfs_lchown(const char *path, uint32_t uid, uint32_t gid);
 int  vfs_fchown(int fd, uint32_t uid, uint32_t gid);
 void vfs_print_mounts(void);
+
+/* Per-process fd-table lifecycle — called from process management. */
+void vfs_inherit_fd_table(struct process *parent, struct process *child);
+void vfs_close_all_fds_for_process(struct process *p);

--- a/fs/vfs.h
+++ b/fs/vfs.h
@@ -81,6 +81,7 @@ typedef struct filesystem {
     int (*read_at)(int fd, uint8_t *buf, size_t len, uint32_t offset);
     int (*write)(int fd, const uint8_t *buf, size_t len);
     int (*close)(int fd);
+    int (*addref)(int fd);   /* increment refcount of an open backend fd (for fork/dup) */
     int (*readdir)(const char *path, vfs_dirent_t *out, int max);
     int (*mkdir)(const char *path);
     int (*unlink)(const char *path);

--- a/grub.cfg
+++ b/grub.cfg
@@ -7,7 +7,7 @@
 serial --unit=0 --speed=115200
 terminal_output --append serial
 
-set timeout=1
+set timeout=0
 set default=0
 
 menuentry "BlueyOS - It's a big day!" {

--- a/include/bluey.h
+++ b/include/bluey.h
@@ -83,6 +83,14 @@ void bluey_panic(const char *msg);
 #define PANIC(msg) bluey_panic(msg)
 
 // ---------------------------------------------------------------------------
+// Kernel errno values (POSIX subset used by the BlueyOS kernel)
+// These match standard Linux errno values so userspace musl sees the right codes.
+// ---------------------------------------------------------------------------
+#define BLUEY_EEXIST  17  /* File/directory already exists */
+#define BLUEY_ENODEV  19  /* No such device */
+#define BLUEY_ENOTDIR 20  /* Not a directory */
+
+// ---------------------------------------------------------------------------
 // Heap magic number - "B10E" loosely reads as "BLUE"
 // Episode ref: "Magic Xylophone" - magic numbers everywhere!
 // ---------------------------------------------------------------------------

--- a/kernel/acpi.c
+++ b/kernel/acpi.c
@@ -1,0 +1,214 @@
+// BlueyOS ACPI Support
+// "Someone's gotta keep the lights on!" - Bandit Heeler
+//
+// Minimal ACPI table parsing: find RSDP, walk RSDT to FADT, extract
+// the reset register and PM1 control ports for proper poweroff/reboot.
+//
+// IMPORTANT: acpi_init() must be called before paging_init().
+// In flat protected mode all physical addresses are directly accessible,
+// so ACPI tables at any location (including high RAM) can be read safely.
+// After paging is on, only I/O-space reset/poweroff operations are used.
+
+#include "acpi.h"
+#include "../include/ports.h"
+#include "../lib/stdio.h"
+#include "../lib/string.h"
+
+// Memory-mapped reset register is only safe to write post-paging if
+// the address falls within the kernel's 4 MB identity map.
+#define ACPI_MMIO_SAFE_MAX  0x00400000u
+
+static int      g_acpi_ok       = 0;
+static int      g_has_reset_reg = 0;
+static uint8_t  g_reset_space   = 0;    // ACPI_GAS_IO or ACPI_GAS_MEMORY
+static uint32_t g_reset_addr    = 0;
+static uint8_t  g_reset_value   = 0;
+static uint16_t g_pm1a_cnt_port = 0;
+static uint16_t g_pm1b_cnt_port = 0;
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+static uint8_t acpi_checksum(const uint8_t *p, uint32_t len) {
+    uint8_t sum = 0;
+    for (uint32_t i = 0; i < len; i++) sum += p[i];
+    return sum;
+}
+
+static acpi_rsdp_t *find_rsdp_in_range(uint32_t start, uint32_t end) {
+    for (uint32_t addr = start; addr < end; addr += 16) {
+        acpi_rsdp_t *r = (acpi_rsdp_t *)(uintptr_t)addr;
+        if (memcmp(r->signature, "RSD PTR ", 8) == 0 &&
+            acpi_checksum((const uint8_t *)r, 20) == 0)
+            return r;
+    }
+    return NULL;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+void acpi_init(void) {
+    // Search Extended BIOS Data Area (first 1 KB)
+    uint32_t ebda_seg = (uint32_t)(*(volatile uint16_t *)(uintptr_t)0x040Eu);
+    uint32_t ebda_base = ebda_seg << 4;
+
+    acpi_rsdp_t *rsdp = NULL;
+    if (ebda_base >= 0x80000u && ebda_base < 0xA0000u)
+        rsdp = find_rsdp_in_range(ebda_base, ebda_base + 1024u);
+
+    // Search BIOS ROM area (0xE0000 – 0xFFFFF)
+    if (!rsdp)
+        rsdp = find_rsdp_in_range(0xE0000u, 0x100000u);
+
+    if (!rsdp) {
+        kprintf("[ACPI] RSDP not found — using legacy reset/poweroff paths\n");
+        return;
+    }
+    kprintf("[ACPI] RSDP at 0x%x (rev=%d oem=%.6s)\n",
+            (uint32_t)(uintptr_t)rsdp, rsdp->revision, rsdp->oem_id);
+
+    uint32_t rsdt_addr = rsdp->rsdt_address;
+    if (!rsdt_addr) {
+        kprintf("[ACPI] RSDT address is zero — skipping table parse\n");
+        g_acpi_ok = 1;
+        return;
+    }
+
+    acpi_sdt_hdr_t *rsdt = (acpi_sdt_hdr_t *)(uintptr_t)rsdt_addr;
+    if (memcmp(rsdt->signature, "RSDT", 4) != 0) {
+        kprintf("[ACPI] RSDT signature invalid at 0x%x\n", rsdt_addr);
+        g_acpi_ok = 1;
+        return;
+    }
+    if (acpi_checksum((const uint8_t *)rsdt, rsdt->length) != 0) {
+        kprintf("[ACPI] RSDT checksum bad — skipping\n");
+        g_acpi_ok = 1;
+        return;
+    }
+
+    // Walk RSDT: each entry is a uint32_t physical address
+    uint32_t *entries = (uint32_t *)((uint8_t *)rsdt + sizeof(acpi_sdt_hdr_t));
+    uint32_t  nentries = (rsdt->length - (uint32_t)sizeof(acpi_sdt_hdr_t)) / 4u;
+
+    for (uint32_t i = 0; i < nentries; i++) {
+        uint32_t entry_addr = entries[i];
+        if (!entry_addr) continue;
+
+        acpi_sdt_hdr_t *sdt = (acpi_sdt_hdr_t *)(uintptr_t)entry_addr;
+        if (memcmp(sdt->signature, "FACP", 4) != 0) continue;
+
+        kprintf("[ACPI] FADT at 0x%x (len=%u rev=%d)\n",
+                entry_addr, sdt->length, sdt->revision);
+
+        acpi_fadt_t *fadt = (acpi_fadt_t *)(uintptr_t)entry_addr;
+
+        // PM1 control ports for poweroff (legacy I/O addresses in FADT)
+        if (fadt->pm1a_cnt_blk) {
+            g_pm1a_cnt_port = (uint16_t)fadt->pm1a_cnt_blk;
+            kprintf("[ACPI] PM1a_CNT port=0x%x\n", g_pm1a_cnt_port);
+        }
+        if (fadt->pm1b_cnt_blk) {
+            g_pm1b_cnt_port = (uint16_t)fadt->pm1b_cnt_blk;
+            kprintf("[ACPI] PM1b_CNT port=0x%x\n", g_pm1b_cnt_port);
+        }
+
+        // Reset register: ACPI 2.0+, requires RESET_REG_SUP flag set
+        if (sdt->revision >= 2 && sdt->length >= 129u &&
+            (fadt->flags & FADT_FLAG_RESET_REG_SUP)) {
+            acpi_gas_t *rreg = &fadt->reset_reg;
+            uint32_t rraddr;
+            memcpy(&rraddr, &rreg->address, 4);  // safe unaligned read of low 32 bits
+
+            if (rreg->address_space == ACPI_GAS_IO && rraddr <= 0xFFFFu) {
+                g_reset_space   = ACPI_GAS_IO;
+                g_reset_addr    = rraddr;
+                g_reset_value   = fadt->reset_value;
+                g_has_reset_reg = 1;
+                kprintf("[ACPI] Reset reg: I/O port 0x%x value=0x%x\n",
+                        g_reset_addr, g_reset_value);
+            } else if (rreg->address_space == ACPI_GAS_MEMORY &&
+                       rraddr < ACPI_MMIO_SAFE_MAX) {
+                g_reset_space   = ACPI_GAS_MEMORY;
+                g_reset_addr    = rraddr;
+                g_reset_value   = fadt->reset_value;
+                g_has_reset_reg = 1;
+                kprintf("[ACPI] Reset reg: MMIO 0x%x value=0x%x\n",
+                        g_reset_addr, g_reset_value);
+            } else {
+                kprintf("[ACPI] Reset reg space=%d addr=0x%x — not usable post-paging\n",
+                        rreg->address_space, rraddr);
+            }
+        }
+
+        g_acpi_ok = 1;
+        break;
+    }
+
+    if (!g_acpi_ok)
+        kprintf("[ACPI] FADT not found in RSDT\n");
+}
+
+int acpi_available(void) {
+    return g_acpi_ok;
+}
+
+// acpi_reset - CPU reset via ACPI reset register, then legacy KBC, then CF9.
+void acpi_reset(void) {
+    // 1. ACPI reset register (if found)
+    if (g_has_reset_reg) {
+        if (g_reset_space == ACPI_GAS_IO) {
+            outb((uint16_t)g_reset_addr, g_reset_value);
+        } else {
+            // Memory-mapped: only safe within 4 MB identity map
+            volatile uint8_t *p = (volatile uint8_t *)(uintptr_t)g_reset_addr;
+            *p = g_reset_value;
+        }
+        // Brief spin to let the hardware respond before trying fallbacks
+        for (volatile int i = 0; i < 100000; i++);
+    }
+
+    // 2. Legacy keyboard controller pulse (works on real PC and QEMU):
+    //    wait for KBC input buffer empty (bit 1 of status port 0x64 = IBF),
+    //    then write the CPU reset pulse command 0xFE to command port 0x64.
+    {
+        int timeout = 100000;
+        while ((inb(0x64u) & 0x02u) && --timeout > 0);
+        outb(0x64u, 0xFEu);
+        for (volatile int i = 0; i < 100000; i++);
+    }
+
+    // 3. Port CF9 hard reset (PCI reset line)
+    outb(0xCF9u, 0x06u);
+}
+
+// acpi_poweroff - ACPI S5 sleep (soft power off) via PM1_CNT registers.
+//
+// SLP_TYP encoding in PM1_CNT: bits [12:10], SLP_EN = bit 13.
+// QEMU/SeaBIOS S5 SLP_TYP is typically 5 (0b101), giving value 0x3400
+// when combined with SLP_EN.  Older QEMU used SLP_TYP=0 (value 0x2000).
+// We try both, plus Bochs's PM port at 0xB004.
+void acpi_poweroff(void) {
+    // 1. Try via parsed PM1a_CNT port (read-modify-write to preserve other bits)
+    if (g_pm1a_cnt_port) {
+        uint16_t val = inw(g_pm1a_cnt_port);
+        val &= ~(uint16_t)0x1C00u;                           // clear SLP_TYP [12:10]
+        val |= (uint16_t)((5u << 10) | (1u << 13));          // SLP_TYP=5, SLP_EN
+        outw(g_pm1a_cnt_port, val);
+        if (g_pm1b_cnt_port) {
+            val = inw(g_pm1b_cnt_port);
+            val &= ~(uint16_t)0x1C00u;
+            val |= (uint16_t)((5u << 10) | (1u << 13));
+            outw(g_pm1b_cnt_port, val);
+        }
+        for (volatile int i = 0; i < 100000; i++);
+    }
+
+    // 2. Hardcoded QEMU/Bochs/SeaBIOS fallback ports (tried in order)
+    outw(0x604u,  0x3400u);   // QEMU PIIX4 PM, SLP_TYP=5
+    outw(0x604u,  0x2000u);   // QEMU PIIX4 PM, SLP_TYP=0 (older QEMU)
+    outw(0xB004u, 0x2000u);   // Bochs
+    outw(0x4004u, 0x3400u);   // SeaBIOS alternate
+}

--- a/kernel/acpi.h
+++ b/kernel/acpi.h
@@ -1,0 +1,103 @@
+#pragma once
+// BlueyOS ACPI Support
+// "Someone's gotta keep the lights on!" - Bandit Heeler
+//
+// Minimal ACPI table parsing for proper reboot/poweroff.
+// acpi_init() must be called BEFORE paging_init() so all physical
+// memory is accessible in flat mode without range restrictions.
+
+#include "../include/types.h"
+
+// ACPI Generic Address Structure (12 bytes, ACPI 2.0+)
+typedef struct __attribute__((packed)) {
+    uint8_t  address_space;  // 0=memory, 1=I/O
+    uint8_t  bit_width;
+    uint8_t  bit_offset;
+    uint8_t  access_size;
+    uint64_t address;
+} acpi_gas_t;
+
+#define ACPI_GAS_MEMORY  0
+#define ACPI_GAS_IO      1
+
+// Root System Description Pointer (20 bytes for ACPI 1.0)
+typedef struct __attribute__((packed)) {
+    char     signature[8];   // "RSD PTR "
+    uint8_t  checksum;
+    char     oem_id[6];
+    uint8_t  revision;       // 0=ACPI 1.0, 2=ACPI 2.0+
+    uint32_t rsdt_address;
+    // ACPI 2.0+ extension:
+    uint32_t length;
+    uint64_t xsdt_address;
+    uint8_t  extended_checksum;
+    uint8_t  reserved[3];
+} acpi_rsdp_t;
+
+// Standard System Description Table header (36 bytes)
+typedef struct __attribute__((packed)) {
+    char     signature[4];
+    uint32_t length;
+    uint8_t  revision;
+    uint8_t  checksum;
+    char     oem_id[6];
+    char     oem_table_id[8];
+    uint32_t oem_revision;
+    uint32_t creator_id;
+    uint32_t creator_revision;
+} acpi_sdt_hdr_t;
+
+// Fixed ACPI Description Table — "FACP"
+typedef struct __attribute__((packed)) {
+    acpi_sdt_hdr_t hdr;              // offset   0 (36 bytes)
+    uint32_t firmware_ctrl;          // offset  36
+    uint32_t dsdt;                   // offset  40
+    uint8_t  reserved0;             // offset  44
+    uint8_t  preferred_pm_profile;  // offset  45
+    uint16_t sci_int;                // offset  46
+    uint32_t smi_cmd;                // offset  48
+    uint8_t  acpi_enable;           // offset  52
+    uint8_t  acpi_disable;          // offset  53
+    uint8_t  s4bios_req;            // offset  54
+    uint8_t  pstate_cnt;            // offset  55
+    uint32_t pm1a_evt_blk;          // offset  56
+    uint32_t pm1b_evt_blk;          // offset  60
+    uint32_t pm1a_cnt_blk;          // offset  64
+    uint32_t pm1b_cnt_blk;          // offset  68
+    uint32_t pm2_cnt_blk;           // offset  72
+    uint32_t pm_tmr_blk;            // offset  76
+    uint32_t gpe0_blk;              // offset  80
+    uint32_t gpe1_blk;              // offset  84
+    uint8_t  pm1_evt_len;           // offset  88
+    uint8_t  pm1_cnt_len;           // offset  89
+    uint8_t  pm2_cnt_len;           // offset  90
+    uint8_t  pm_tmr_len;            // offset  91
+    uint8_t  gpe0_blk_len;          // offset  92
+    uint8_t  gpe1_blk_len;          // offset  93
+    uint8_t  gpe1_base;             // offset  94
+    uint8_t  cst_cnt;               // offset  95
+    uint16_t p_lvl2_lat;            // offset  96
+    uint16_t p_lvl3_lat;            // offset  98
+    uint16_t flush_size;            // offset 100
+    uint16_t flush_stride;          // offset 102
+    uint8_t  duty_offset;           // offset 104
+    uint8_t  duty_width;            // offset 105
+    uint8_t  day_alrm;              // offset 106
+    uint8_t  mon_alrm;              // offset 107
+    uint8_t  century;               // offset 108
+    uint16_t iapc_boot_arch;        // offset 109
+    uint8_t  reserved1;             // offset 111
+    uint32_t flags;                  // offset 112 (4 bytes)
+    acpi_gas_t reset_reg;            // offset 116 (12 bytes)
+    uint8_t  reset_value;           // offset 128
+    uint8_t  reserved2[3];          // offset 129
+    // ACPI 2.0+ extended fields start at offset 132 (not used here)
+} acpi_fadt_t;
+
+// FADT flags: bit 10 = RESET_REG_SUP
+#define FADT_FLAG_RESET_REG_SUP  (1u << 10)
+
+void acpi_init(void);
+int  acpi_available(void);
+void acpi_reset(void);
+void acpi_poweroff(void);

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -60,6 +60,7 @@
 #include "netcfg.h"
 #include "devev.h"
 #include "socket.h"
+#include "acpi.h"
 
 #define MULTIBOOT_BOOTLOADER_MAGIC 0x2BADB002u
 #define MULTIBOOT_INFO_MEMORY 0x00000001u
@@ -207,6 +208,10 @@ void kernel_main(uint32_t magic, uint32_t *mboot_info) {
 
     // Step 6: Keyboard - PS/2, IRQ1 (module)
     module_load("keyboard");
+
+    // Step 6b: ACPI table parse — must run before paging_init() so all
+    // physical memory is accessible in flat protected mode.
+    acpi_init();
 
     // Step 7: Paging / virtual memory
     paging_init();

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -12,8 +12,10 @@
 #include "tty.h"
 #include "../fs/vfs.h"
 
-#define BLUEY_EAGAIN 11
-#define BLUEY_EINVAL 22
+#define BLUEY_EAGAIN  11
+#define BLUEY_EINVAL  22
+/* Kernel-internal: must match the value in syscall.c */
+#define BLUEY_ERESTART 512
 
 /*
  * Determine readiness of a single fd.
@@ -55,6 +57,18 @@ static int16_t poll_check_fd(int32_t fd, int16_t events) {
         return ready;
     }
 
+    if (vfs_fd_is_pipe(fd)) {
+        /* Read end: data available or EOF (all writers closed). */
+        if (events & POLLIN) {
+            if (vfs_pipe_readable(fd)) ready |= POLLIN;
+        }
+        /* Write end: space available and at least one reader open. */
+        if (events & POLLOUT) {
+            if (vfs_pipe_writable(fd)) ready |= POLLOUT;
+        }
+        return ready;
+    }
+
     /* Generic VFS file: assume readable/writable (basic approximation) */
     if (events & POLLIN)  ready |= POLLIN;
     if (events & POLLOUT) ready |= POLLOUT;
@@ -77,19 +91,16 @@ int kernel_poll(pollfd_t *fds, uint32_t nfds, int32_t timeout_ms) {
     if (ready > 0 || timeout_ms == 0) return ready;
 
     /*
-     * Nothing is ready and the caller wants to wait.
-     * Put the process to sleep for min(timeout_ms, 50) ms so other
-     * processes can run, then signal the caller to retry via -EAGAIN.
-     * (The syscall wrapper in userspace must loop on EAGAIN.)
+     * Nothing is ready and the caller wants to wait.  Sleep for
+     * min(|timeout_ms|, 50) ms so other processes can run, then signal
+     * the syscall dispatcher to retry the entire poll syscall via the
+     * kernel-internal ERESTART mechanism (invisible to user space).
      */
-    if (timeout_ms < 0) {
-        /* Infinite wait — block until woken by an event */
-        process_set_waiting(process_current());
-    } else {
-        uint32_t sleep_ms = (uint32_t)timeout_ms;
+    {
+        uint32_t sleep_ms = (timeout_ms < 0) ? 50u : (uint32_t)timeout_ms;
         if (sleep_ms > 50u) sleep_ms = 50u;
         process_sleep(sleep_ms);
     }
 
-    return -BLUEY_EAGAIN;
+    return -BLUEY_ERESTART;
 }

--- a/kernel/process.c
+++ b/kernel/process.c
@@ -16,6 +16,7 @@
 #include "gdt.h"
 #include "multiuser.h"
 #include "devev.h"
+#include "../fs/vfs.h"
 
 #define BLUEY_ECHILD 10
 #define BLUEY_EAGAIN 11
@@ -460,6 +461,7 @@ process_t *process_fork_current(const registers_t *regs, int32_t *error_out) {
     child->blocked_signals = parent->blocked_signals;
     memcpy(child->signal_actions, parent->signal_actions, sizeof(child->signal_actions));
     memcpy(child->cwd, parent->cwd, sizeof(child->cwd));
+    vfs_inherit_fd_table(parent, child);
     child->saved_regs = *regs;
     child->saved_regs.eax = 0;
     child->eip = child->saved_regs.eip;
@@ -688,6 +690,9 @@ void process_mark_exited(process_t *process, int code) {
     process->state = PROC_ZOMBIE;
     process->exit_code = code;
     process->pending_signals = 0;
+
+    /* Close all open file descriptors — release pipe/socket refcounts. */
+    vfs_close_all_fds_for_process(process);
 
     if (process->clear_child_tid) {
         process_write_user_u32(process, process->clear_child_tid, 0);

--- a/kernel/process.h
+++ b/kernel/process.h
@@ -5,6 +5,7 @@
 // licensed by BBC Studios. BlueyOS is an unofficial fan/research project.
 #include "../include/types.h"
 #include "idt.h"
+#include "../fs/vfs.h"
 
 #define MAX_PROCESSES  64
 #define PROC_STACK_SIZE 8192   // 8 KiB per process stack
@@ -80,6 +81,7 @@ typedef struct process {
     int32_t       futex_wait_result;
     uint8_t       futex_wait_private;
     char          cwd[256];          // current working directory
+    vfs_fd_t      fd_table[VFS_MAX_OPEN]; // per-process file descriptor table
     registers_t   saved_regs;
     process_sigaction_t signal_actions[32];
     struct process *next;

--- a/kernel/scheduler.c
+++ b/kernel/scheduler.c
@@ -16,6 +16,10 @@
 
 static process_t *run_queue   = NULL;   // circular linked list of runnable processes
 static process_t *sched_current = NULL;
+/* Set to 1 when the scheduler has entered the idle fallback loop.
+ * Only when this flag is set is it safe to replace the interrupt frame
+ * with a user-mode context (the idle loop has nothing to clean up). */
+static volatile int sched_in_idle_fallback = 0;
 
 /* ---------------------------------------------------------------------------
  * Completely Fair Scheduler (CFS)
@@ -74,6 +78,7 @@ static uint64_t cfs_min_vruntime(void) {
 }
 
 static void scheduler_idle_fallback(void) {
+    sched_in_idle_fallback = 1;
     for (;;) __asm__ volatile("sti; hlt");
 }
 
@@ -217,14 +222,18 @@ void scheduler_handle_trap(registers_t *regs, int rotate) {
                 ((regs->cs & 0x3u) == 0x3u);
 
     /*
-     * Allow scheduling from the idle fallback (current == NULL).  When all
-     * processes were sleeping, scheduler_prepare_fallback_frame() set current
-     * to NULL and returned to scheduler_idle_fallback.  The next timer tick
-     * calls scheduler_tick() which wakes any process whose sleep_until has
-     * elapsed.  Without this exception the early-return would prevent those
-     * freshly-woken processes from ever being dispatched.
+     * Allow scheduling from the idle fallback (current == NULL and
+     * sched_in_idle_fallback == 1).  When all user processes were sleeping,
+     * scheduler_prepare_fallback_frame() set current to NULL and redirected
+     * execution to scheduler_idle_fallback.  The next timer tick calls
+     * scheduler_tick() which wakes any process whose sleep_until has elapsed.
+     * Without this exception the early-return would prevent those freshly-woken
+     * processes from ever being dispatched.
+     *
+     * The flag check prevents accidentally hijacking kernel bootstrap code that
+     * runs with current==NULL before any user process is created.
      */
-    if (!user_trap && current != NULL) {
+    if (!user_trap && !(current == NULL && sched_in_idle_fallback)) {
         return;
     }
 
@@ -288,6 +297,7 @@ void scheduler_handle_trap(registers_t *regs, int rotate) {
         process_set_current(next);
         /* start accounting from current tick */
         next->cpu_last_tick = timer_get_ticks();
+        sched_in_idle_fallback = 0;   /* leaving idle fallback, if we were in it */
         *regs = frame;
         return;
     }

--- a/kernel/scheduler.c
+++ b/kernel/scheduler.c
@@ -216,7 +216,15 @@ void scheduler_handle_trap(registers_t *regs, int rotate) {
                 (current->flags & PROC_FLAG_USER_MODE) &&
                 ((regs->cs & 0x3u) == 0x3u);
 
-    if (!user_trap) {
+    /*
+     * Allow scheduling from the idle fallback (current == NULL).  When all
+     * processes were sleeping, scheduler_prepare_fallback_frame() set current
+     * to NULL and returned to scheduler_idle_fallback.  The next timer tick
+     * calls scheduler_tick() which wakes any process whose sleep_until has
+     * elapsed.  Without this exception the early-return would prevent those
+     * freshly-woken processes from ever being dispatched.
+     */
+    if (!user_trap && current != NULL) {
         return;
     }
 

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -33,6 +33,8 @@
 #include "syslog.h"
 #include "../net/tcpip.h"
 #include "../fs/vfs.h"
+#include "../fs/blueyfs.h"
+#include "acpi.h"
 
 extern void syscall_stub(void);
 extern void syscall_enter_user_frame(const registers_t *regs);
@@ -1084,8 +1086,11 @@ static int32_t sys_rmdir(const char *path) {
     if (!path) return -BLUEY_EFAULT;
     char _rpath[512];
     if (resolve_normalize_path(path, _rpath, sizeof(_rpath)) != 0) return -BLUEY_EINVAL;
+    vfs_stat_t st;
+    if (vfs_stat(_rpath, &st) != 0) return -BLUEY_ENOENT;
+    if (!st.is_dir) return -BLUEY_ENOTDIR;
     int32_t res = vfs_rmdir(_rpath);
-    return res;
+    return (res == 0) ? 0 : -BLUEY_EPERM;
 }
 
 typedef struct {
@@ -2681,11 +2686,17 @@ static int32_t sys_write(uint32_t fd, const char *buf, size_t len) {
     return -BLUEY_EBADF;
 }
 
+/* O_DIRECTORY (0x10000): caller requires the path to be a directory.
+ * Our VFS strips this flag before calling the FS backend, so we must
+ * enforce the ENOTDIR semantics here explicitly. */
+#define LINUX_O_DIRECTORY  0x10000
+
 static int32_t sys_open(const char *path, int flags) {
     vfs_stat_t stat;
     int access_mode;
     int vfs_flags;
     int fd;
+    int stat_ok;
 
     if (!path) return -BLUEY_EFAULT;
 
@@ -2696,8 +2707,15 @@ static int32_t sys_open(const char *path, int flags) {
     access_mode = flags & 0x3;
     vfs_flags = access_mode | (flags & (VFS_O_CREAT | VFS_O_TRUNC | VFS_O_APPEND));
 
-    if (vfs_stat(path, &stat) != 0) {
+    memset(&stat, 0, sizeof(stat));
+    stat_ok = (vfs_stat(path, &stat) == 0);
+    if (!stat_ok) {
         if (!(vfs_flags & VFS_O_CREAT)) return -BLUEY_ENOENT;
+    }
+
+    /* O_DIRECTORY: if the path exists and is not a directory, fail. */
+    if ((flags & LINUX_O_DIRECTORY) && stat_ok && !stat.is_dir) {
+        return -BLUEY_ENOTDIR;
     }
 
     fd = vfs_open(path, vfs_flags);
@@ -2934,21 +2952,20 @@ static int32_t sys_getpgrp(void) {
 
 /* ---- Mount / umount ---------------------------------------------------- */
 
-static int32_t sys_sync(void) {
-    process_t *caller = process_current();
-    int ata_ret;
-
-    if (!caller) return -BLUEY_EPERM;
-    if (caller->euid != 0 && caller->pid != 1) return -BLUEY_EPERM;
-
-    /* tty/syslog flush APIs are best-effort and currently void-returning. */
+/* Flush all kernel state to disk.  Called from both sys_sync() and
+ * sys_reboot() — no permission check, caller is responsible. */
+static void kernel_sync(void) {
     tty_flush();
     syslog_flush_to_fs();
-    ata_ret = ata_flush_cache();
-    if (ata_ret != 0) {
-        kprintf("[SYS]  sync(): ATA cache flush failed (%d)\n", ata_ret);
-        return -BLUEY_EIO;
-    }
+    biscuitfs_journal_commit();   // flush any pending journal transaction
+    ata_flush_cache();            // flush ATA write cache to platter
+}
+
+static int32_t sys_sync(void) {
+    process_t *caller = process_current();
+    if (!caller) return -BLUEY_EPERM;
+    if (caller->euid != 0 && caller->pid != 1) return -BLUEY_EPERM;
+    kernel_sync();
     return 0;
 }
 
@@ -3000,21 +3017,24 @@ static int32_t sys_devev_open(void) {
 static int32_t sys_reboot(uint32_t magic1, uint32_t magic2, uint32_t cmd) {
     if (magic1 != REBOOT_MAGIC1 || magic2 != REBOOT_MAGIC2) return -BLUEY_EINVAL;
 
-    kprintf("[SYS]  Reboot/poweroff requested (cmd=0x%x) - bye bye!\n", cmd);
+    /* Only root or PID 1 may reboot/poweroff */
+    process_t *caller = process_current();
+    if (caller && caller->euid != 0 && caller->pid != 1) return -BLUEY_EPERM;
+    if (cmd != REBOOT_CMD_RESTART && cmd != REBOOT_CMD_POWER_OFF) return -BLUEY_EINVAL;
+
+    kprintf("[SYS]  %s requested — syncing filesystem...\n",
+            cmd == REBOOT_CMD_RESTART ? "Reboot" : "Poweroff");
+
+    /* Flush journals and ATA cache before pulling the plug */
+    kernel_sync();
+
+    kprintf("[SYS]  Sync complete — goodbye!\n");
     __asm__ volatile("cli");
 
     if (cmd == REBOOT_CMD_RESTART) {
-        /* Keyboard controller CPU reset (works on real PC and QEMU) */
-        uint8_t val;
-        do { val = inb(0x64); } while (val & 0x02u);
-        outb(0x64, 0xFE);
-        /* Fallback: port 0xCF9 hard reset */
-        outb(0xCF9, 0x06u);
+        acpi_reset();
     } else {
-        /* ACPI S5 poweroff — tried in order of most-to-least likely */
-        outw(0x604, 0x2000);
-        outw(0xB004, 0x2000);  /* older QEMU / Bochs */
-        outw(0x4004, 0x3400);  /* SeaBIOS */
+        acpi_poweroff();
     }
 
     /* Should never reach here */

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -71,6 +71,17 @@ uint32_t syscall_saved_gs = 0;
 #define BLUEY_ECONNREFUSED 111
 #define BLUEY_ENOMEM 12
 
+/*
+ * Kernel-internal restart code.  When a blocking syscall (read on an empty
+ * pipe, poll with no ready fds, …) needs to sleep and retry, it calls
+ * process_sleep() then returns -BLUEY_ERESTART.  The syscall dispatcher
+ * detects this value, backs up EIP by 2 bytes (the size of `int 0x80`) so
+ * that the instruction is re-executed after the sleep expires, and lets the
+ * scheduler switch to another process.  This value is never visible in user
+ * space.
+ */
+#define BLUEY_ERESTART 512
+
 #define EXEC_COPY_MAX_STRINGS    64u
 #define EXEC_COPY_MAX_STRING_LEN 256u
 
@@ -1523,6 +1534,7 @@ static int32_t sys_select(int nfds,
             else if (vfs_fd_is_devev(fd)) is_ready = devev_pending();
             else if (vfs_fd_is_tty(fd)) is_ready = tty_input_pending();
             else if (vfs_fd_is_socket(fd)) is_ready = socket_is_readable(vfs_socket_id(fd));
+            else if (vfs_fd_is_pipe(fd)) is_ready = vfs_pipe_readable(fd);
             else if (fd >= 3 && vfs_fd_is_open(fd)) is_ready = 1;
 
             if (is_ready) {
@@ -1536,6 +1548,7 @@ static int32_t sys_select(int nfds,
             if (fd == 1 || fd == 2) is_ready = 1;
             else if (vfs_fd_is_tty(fd)) is_ready = 1;
             else if (vfs_fd_is_socket(fd)) is_ready = socket_is_writable(vfs_socket_id(fd));
+            else if (vfs_fd_is_pipe(fd)) is_ready = vfs_pipe_writable(fd);
             else if (fd >= 3 && vfs_fd_is_open(fd)) is_ready = 1;
 
             if (is_ready) {
@@ -1545,16 +1558,18 @@ static int32_t sys_select(int nfds,
         }
     }
 
-    if (rfds) memcpy(rfds, ready_read, sizeof(ready_read));
-    if (wfds) memcpy(wfds, ready_write, sizeof(ready_write));
-
-    if (ready > 0) return (int32_t)ready;
+    if (ready > 0) {
+        /* Write results to user space only when returning success. */
+        if (rfds) memcpy(rfds, ready_read, sizeof(ready_read));
+        if (wfds) memcpy(wfds, ready_write, sizeof(ready_write));
+        return (int32_t)ready;
+    }
 
     /* claw currently uses select(0, NULL, NULL, NULL, &tv) as a timed sleep. */
     if (nfds == 0) {
         if (!timeout) {
-            process_set_waiting(process_current());
-            return 0;
+            process_sleep(50);
+            return -BLUEY_ERESTART;
         }
 
         if (timeout->tv_sec < 0 || timeout->tv_usec < 0 || timeout->tv_usec >= 1000000) {
@@ -1568,8 +1583,10 @@ static int32_t sys_select(int nfds,
     }
 
     if (!timeout) {
-        process_set_waiting(process_current());
-        return 0;
+        /* Infinite wait: sleep 50 ms then retry via the ERESTART mechanism.
+         * Do NOT write to rfds/wfds — they must be intact for the restart. */
+        process_sleep(50);
+        return -BLUEY_ERESTART;
     }
 
     if (timeout->tv_sec < 0 || timeout->tv_usec < 0 || timeout->tv_usec >= 1000000) {
@@ -1582,6 +1599,7 @@ static int32_t sys_select(int nfds,
         if (ms) process_sleep(ms);
     }
 
+    /* Timeout expired with no ready fds — zero the output sets. */
     if (rfds) memset(rfds, 0, sizeof(ready_read));
     if (wfds) memset(wfds, 0, sizeof(ready_write));
     return 0;
@@ -2845,6 +2863,8 @@ static int32_t sys_execve(registers_t *regs,
         process_set_effective_ids(process, new_euid, new_egid);
     }
     result = 0;
+    kprintf("[SYS] execve: launched pid=%u name=%s entry=0x%x esp=0x%x\n",
+            process->pid, process->name, process->eip, process->esp);
 
     if (old_page_dir && old_page_dir != image.page_dir) {
         if (!had_vfork_shared_vm) {
@@ -2874,23 +2894,54 @@ static int32_t sys_read(uint32_t fd, char *buf, size_t len) {
     if (vfs_fd_is_open((int)fd)) {
         if (!buf) return -BLUEY_EFAULT;
         if (len == 0) return 0;
-        return vfs_read((int)fd, (uint8_t *)buf, len);
+        if (vfs_fd_is_tty((int)fd)) {
+            /* Non-blocking TTY read: if no data is ready, sleep 1 ms and
+             * restart the syscall so the scheduler can run other processes. */
+            int r = tty_read_nb(buf, len);
+            if (r == 0) {
+                process_sleep(1);
+                return -BLUEY_ERESTART;
+            }
+            return r;
+        }
+        int r = vfs_read((int)fd, (uint8_t *)buf, len);
+        /* Blocking pipe: empty with writers — sleep 1 ms and restart. */
+        if (r == -BLUEY_EAGAIN && vfs_fd_is_pipe((int)fd)) {
+            process_sleep(1);
+            return -BLUEY_ERESTART;
+        }
+        return r;
     }
 
     if (fd == 0) {
         if (!buf) return -BLUEY_EFAULT;
         if (len == 0) return 0;
-        return tty_read(buf, len);
+        /* Non-blocking TTY read for fd 0 (unmapped stdin). */
+        int r = tty_read_nb(buf, len);
+        if (r == 0) {
+            process_sleep(1);
+            return -BLUEY_ERESTART;
+        }
+        return r;
     }
     if (vfs_fd_is_tty((int)fd)) {
         if (!buf) return -BLUEY_EFAULT;
         if (len == 0) return 0;
-        return vfs_read((int)fd, (uint8_t *)buf, len);
+        int r = tty_read_nb(buf, len);
+        if (r == 0) {
+            process_sleep(1);
+            return -BLUEY_ERESTART;
+        }
+        return r;
     }
     if (fd >= 3) {
         if (!buf) return -BLUEY_EFAULT;
         if (len == 0) return 0;
         int r = vfs_read((int)fd, (uint8_t *)buf, len);
+        if (r == -BLUEY_EAGAIN && vfs_fd_is_pipe((int)fd)) {
+            process_sleep(1);
+            return -BLUEY_ERESTART;
+        }
         return r;
     }
     return -BLUEY_EBADF;
@@ -3091,8 +3142,11 @@ static int32_t sys_delete_module(const char *name, uint32_t flags) {
 // regs.eax = syscall number, regs.ebx = arg1, regs.ecx = arg2, regs.edx = arg3
 int32_t syscall_dispatch(registers_t *regs) {
     int32_t ret = -1;
+    uint32_t syscall_num;
     process_t *current;
     if (!regs) return -1;
+
+    syscall_num = regs->eax;
 
     current = process_current();
     if (current && (current->flags & PROC_FLAG_LINUX_ABI)) {
@@ -3610,7 +3664,18 @@ int32_t syscall_dispatch(registers_t *regs) {
         }
     }
 syscall_out:
-    regs->eax = ret;
+    if (ret == -BLUEY_ERESTART) {
+        /*
+         * The syscall needs to be retried after the current process wakes
+         * from its sleep.  Back EIP up by 2 bytes (size of `int 0x80`) so
+         * the instruction is re-executed, and restore the original syscall
+         * number in eax so the dispatcher routes correctly on retry.
+         */
+        regs->eax = syscall_num;
+        if (regs->eip >= 2u) regs->eip -= 2u;
+    } else {
+        regs->eax = (uint32_t)ret;
+    }
     scheduler_handle_trap(regs, 0);
     return ret;
 }

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -2160,6 +2160,13 @@ typedef struct { uint16_t ws_row; uint16_t ws_col;
                  uint16_t ws_xpixel; uint16_t ws_ypixel; } k_winsize_t;
 
 static int32_t sys_ioctl(int fd, uint32_t request, void *arg) {
+    /* Bash ioctl tracing: log key terminal control calls. */
+    {
+        process_t *_tp = process_current();
+        if (_tp && strcmp(_tp->name, "bash") == 0)
+            kprintf("[BTRACE] bash ioctl fd=%d req=0x%04x arg=%p\n",
+                    fd, request, arg);
+    }
     if (fd == 0 || fd == 1 || fd == 2 || vfs_fd_is_tty(fd)) {
         if ((request == IOCTL_TIOCGWINSZ || request == IOCTL_TCGETS ||
              request == IOCTL_TCSETS || request == IOCTL_TCSETSW ||
@@ -2649,6 +2656,20 @@ void syscall_init(void) {
 
 // SYS_WRITE (1): fd=1/2 -> stdout/stderr -> TTY; fd>=3 -> VFS
 static int32_t sys_write(uint32_t fd, const char *buf, size_t len) {
+    /* Bash write tracing: log every write from bash so we can confirm whether
+     * bash is calling write() and whether the TTY path is delivering output. */
+    {
+        process_t *_tp = process_current();
+        if (_tp && strcmp(_tp->name, "bash") == 0) {
+            char _pb[17];
+            int  _pn = (int)len < 16 ? (int)len : 16;
+            for (int _i = 0; _i < _pn; _i++)
+                _pb[_i] = (buf && buf[_i] >= 32 && (unsigned char)buf[_i] < 127) ? buf[_i] : '.';
+            _pb[_pn] = '\0';
+            kprintf("[BTRACE] bash write fd=%d len=%u vfs=%d preview='%s'\n",
+                    (int)fd, (unsigned)len, vfs_fd_is_open((int)fd), _pb);
+        }
+    }
     /* If userspace remapped this descriptor via dup/dup2/fcntl(F_DUPFD),
      * honor the VFS binding first (including fd 0/1/2). */
     if (vfs_fd_is_open((int)fd)) {
@@ -2710,6 +2731,14 @@ static int32_t sys_write(uint32_t fd, const char *buf, size_t len) {
 #define LINUX_O_DIRECTORY  0x10000
 
 static int32_t sys_open(const char *path, int flags) {
+    /* Bash open tracing: log every open() from bash to track init script
+     * reading and library/data file access. */
+    {
+        process_t *_tp = process_current();
+        if (_tp && strcmp(_tp->name, "bash") == 0)
+            kprintf("[BTRACE] bash open path=%s flags=0x%x\n",
+                    path ? path : "(null)", flags);
+    }
     vfs_stat_t stat;
     int access_mode;
     int vfs_flags;
@@ -3149,6 +3178,17 @@ int32_t syscall_dispatch(registers_t *regs) {
     syscall_num = regs->eax;
 
     current = process_current();
+
+    /* Bash-specific syscall tracing: log the first 20 syscalls and every 200th
+     * to confirm bash is running and show its early initialisation sequence. */
+    if (current && strcmp(current->name, "bash") == 0) {
+        static uint32_t bash_sc_count = 0;
+        bash_sc_count++;
+        if (bash_sc_count <= 20 || bash_sc_count % 200 == 0)
+            kprintf("[BTRACE] bash syscall #%u type=%u eip=0x%08x ebx=0x%x ecx=0x%x\n",
+                    bash_sc_count, syscall_num, regs->eip, regs->ebx, regs->ecx);
+    }
+
     if (current && (current->flags & PROC_FLAG_LINUX_ABI)) {
         switch (regs->eax) {
             case 1:

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -2756,6 +2756,10 @@ static int32_t sys_open(const char *path, int flags) {
 
     memset(&stat, 0, sizeof(stat));
     stat_ok = (vfs_stat(path, &stat) == 0);
+    /* Debug logging for /dev/ paths to trace open failures */
+    if (path[1] == 'd' && path[2] == 'e' && path[3] == 'v' && path[4] == '/') {
+        kprintf("[OPEN_DBG] path=%s flags=0x%x stat_ok=%d\n", path, flags, stat_ok);
+    }
     if (!stat_ok) {
         if (!(vfs_flags & VFS_O_CREAT)) return -BLUEY_ENOENT;
     }
@@ -2766,6 +2770,9 @@ static int32_t sys_open(const char *path, int flags) {
     }
 
     fd = vfs_open(path, vfs_flags);
+    if (path[1] == 'd' && path[2] == 'e' && path[3] == 'v' && path[4] == '/') {
+        kprintf("[OPEN_DBG] vfs_open path=%s fd=%d lasterr=%d\n", path, fd, vfs_get_last_error());
+    }
     if (fd >= 0) return fd;
 
     if (vfs_get_last_error() == VFS_ERR_EMFILE || vfs_get_last_error() == VFS_ERR_ENFILE) {

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -2160,13 +2160,6 @@ typedef struct { uint16_t ws_row; uint16_t ws_col;
                  uint16_t ws_xpixel; uint16_t ws_ypixel; } k_winsize_t;
 
 static int32_t sys_ioctl(int fd, uint32_t request, void *arg) {
-    /* Bash ioctl tracing: log key terminal control calls. */
-    {
-        process_t *_tp = process_current();
-        if (_tp && strcmp(_tp->name, "bash") == 0)
-            kprintf("[BTRACE] bash ioctl fd=%d req=0x%04x arg=%p\n",
-                    fd, request, arg);
-    }
     if (fd == 0 || fd == 1 || fd == 2 || vfs_fd_is_tty(fd)) {
         if ((request == IOCTL_TIOCGWINSZ || request == IOCTL_TCGETS ||
              request == IOCTL_TCSETS || request == IOCTL_TCSETSW ||
@@ -2656,20 +2649,6 @@ void syscall_init(void) {
 
 // SYS_WRITE (1): fd=1/2 -> stdout/stderr -> TTY; fd>=3 -> VFS
 static int32_t sys_write(uint32_t fd, const char *buf, size_t len) {
-    /* Bash write tracing: log every write from bash so we can confirm whether
-     * bash is calling write() and whether the TTY path is delivering output. */
-    {
-        process_t *_tp = process_current();
-        if (_tp && strcmp(_tp->name, "bash") == 0) {
-            char _pb[17];
-            int  _pn = (int)len < 16 ? (int)len : 16;
-            for (int _i = 0; _i < _pn; _i++)
-                _pb[_i] = (buf && buf[_i] >= 32 && (unsigned char)buf[_i] < 127) ? buf[_i] : '.';
-            _pb[_pn] = '\0';
-            kprintf("[BTRACE] bash write fd=%d len=%u vfs=%d preview='%s'\n",
-                    (int)fd, (unsigned)len, vfs_fd_is_open((int)fd), _pb);
-        }
-    }
     /* If userspace remapped this descriptor via dup/dup2/fcntl(F_DUPFD),
      * honor the VFS binding first (including fd 0/1/2). */
     if (vfs_fd_is_open((int)fd)) {
@@ -2731,14 +2710,6 @@ static int32_t sys_write(uint32_t fd, const char *buf, size_t len) {
 #define LINUX_O_DIRECTORY  0x10000
 
 static int32_t sys_open(const char *path, int flags) {
-    /* Bash open tracing: log every open() from bash to track init script
-     * reading and library/data file access. */
-    {
-        process_t *_tp = process_current();
-        if (_tp && strcmp(_tp->name, "bash") == 0)
-            kprintf("[BTRACE] bash open path=%s flags=0x%x\n",
-                    path ? path : "(null)", flags);
-    }
     vfs_stat_t stat;
     int access_mode;
     int vfs_flags;
@@ -2756,10 +2727,6 @@ static int32_t sys_open(const char *path, int flags) {
 
     memset(&stat, 0, sizeof(stat));
     stat_ok = (vfs_stat(path, &stat) == 0);
-    /* Debug logging for /dev/ paths to trace open failures */
-    if (path[1] == 'd' && path[2] == 'e' && path[3] == 'v' && path[4] == '/') {
-        kprintf("[OPEN_DBG] path=%s flags=0x%x stat_ok=%d\n", path, flags, stat_ok);
-    }
     if (!stat_ok) {
         if (!(vfs_flags & VFS_O_CREAT)) return -BLUEY_ENOENT;
     }
@@ -2770,9 +2737,6 @@ static int32_t sys_open(const char *path, int flags) {
     }
 
     fd = vfs_open(path, vfs_flags);
-    if (path[1] == 'd' && path[2] == 'e' && path[3] == 'v' && path[4] == '/') {
-        kprintf("[OPEN_DBG] vfs_open path=%s fd=%d lasterr=%d\n", path, fd, vfs_get_last_error());
-    }
     if (fd >= 0) return fd;
 
     if (vfs_get_last_error() == VFS_ERR_EMFILE || vfs_get_last_error() == VFS_ERR_ENFILE) {
@@ -3185,16 +3149,6 @@ int32_t syscall_dispatch(registers_t *regs) {
     syscall_num = regs->eax;
 
     current = process_current();
-
-    /* Bash-specific syscall tracing: log the first 20 syscalls and every 200th
-     * to confirm bash is running and show its early initialisation sequence. */
-    if (current && strcmp(current->name, "bash") == 0) {
-        static uint32_t bash_sc_count = 0;
-        bash_sc_count++;
-        if (bash_sc_count <= 20 || bash_sc_count % 200 == 0)
-            kprintf("[BTRACE] bash syscall #%u type=%u eip=0x%08x ebx=0x%x ecx=0x%x\n",
-                    bash_sc_count, syscall_num, regs->eip, regs->ebx, regs->ecx);
-    }
 
     if (current && (current->flags & PROC_FLAG_LINUX_ABI)) {
         switch (regs->eax) {

--- a/kernel/tty.c
+++ b/kernel/tty.c
@@ -150,12 +150,37 @@ char tty_getchar(void) {
     return ch;
 }
 
+/* Non-blocking variant: polls once then returns immediately.
+ * Returns 1 and sets *out if a character was available, 0 otherwise. */
+int tty_getchar_nb(char *out) {
+    tty_poll_input_sources();
+    if (!tty_input_available()) return 0;
+    *out = (char)tty_input_pop();
+    return 1;
+}
+
 int tty_read(char *buf, size_t len) {
     if (!buf || len == 0) return 0;
 
     size_t nread = 0;
     while (nread < len) {
         char ch = tty_getchar();
+        buf[nread++] = ch;
+        if ((tty_console.termios.c_lflag & TTY_LFLAG_ICANON) && ch == '\n') break;
+    }
+
+    return (int)nread;
+}
+
+/* Non-blocking read: tries to fill buf with whatever is immediately available.
+ * Returns 0 if no input is ready, otherwise returns the number of bytes read. */
+int tty_read_nb(char *buf, size_t len) {
+    if (!buf || len == 0) return 0;
+
+    size_t nread = 0;
+    while (nread < len) {
+        char ch;
+        if (!tty_getchar_nb(&ch)) break;
         buf[nread++] = ch;
         if ((tty_console.termios.c_lflag & TTY_LFLAG_ICANON) && ch == '\n') break;
     }

--- a/kernel/tty.c
+++ b/kernel/tty.c
@@ -197,15 +197,6 @@ void tty_flush(void) {
 }
 
 void tty_input_char(char c) {
-    static uint32_t tty_in_count = 0;
-    if (tty_in_count < 50) {
-        kprintf("[TTY-IN#%u] 0x%02x '%c'\n",
-                tty_in_count,
-                (unsigned char)c,
-                (c >= 0x20 && c < 0x7f) ? c : '.');
-        tty_in_count++;
-    }
-
     if (tty_console.termios.c_iflag & TTY_IFLAG_ICRNL) {
         if (c == '\r') c = '\n';
     }
@@ -276,17 +267,12 @@ int tty_ioctl(uint32_t request, void *arg) {
             if (arg) memcpy(&tty_console.termios, arg, sizeof(tty_console.termios));
             return 0;
         case 0x540F: {  /* TIOCGPGRP */
-            static uint32_t tiocgpgrp_count = 0;
             if (!arg) return -1;
             *(uint32_t*)arg = tty_console.fg_pgid;
-            if (tiocgpgrp_count++ < 5)
-                kprintf("[TTY] TIOCGPGRP: returning fg_pgid=%u\n", tty_console.fg_pgid);
             return 0;
         }
         case 0x5410: {  /* TIOCSPGRP */
             if (!arg) return -1;
-            kprintf("[TTY] TIOCSPGRP: fg_pgid %u -> %u\n",
-                    tty_console.fg_pgid, *(uint32_t*)arg);
             tty_console.fg_pgid = *(uint32_t*)arg;
             return 0;
         }
@@ -296,7 +282,6 @@ int tty_ioctl(uint32_t request, void *arg) {
             process_t *p = process_current();
             if (p) {
                 tty_console.fg_pgid = p->pgid;
-                kprintf("[TTY] TIOCSCTTY: fg_pgid set to %u\n", p->pgid);
             }
             return 0;
         }
@@ -336,10 +321,6 @@ int tty_input_pending(void) {
 
 void tty_inject_raw(const char *buf, int len) {
     if (!buf || len <= 0) return;
-    kprintf("[TTY-INJECT] %d bytes:", len);
-    for (int i = 0; i < len && i < 8; i++)
-        kprintf(" %02x", (unsigned char)buf[i]);
-    kprintf("\n");
     for (int i = 0; i < len; i++)
         tty_input_push(buf[i]);
 }

--- a/kernel/tty.c
+++ b/kernel/tty.c
@@ -282,3 +282,9 @@ int tty_input_pending(void) {
     tty_poll_input_sources();
     return tty_input_available();
 }
+
+void tty_inject_raw(const char *buf, int len) {
+    if (!buf || len <= 0) return;
+    for (int i = 0; i < len; i++)
+        tty_input_push(buf[i]);
+}

--- a/kernel/tty.c
+++ b/kernel/tty.c
@@ -63,7 +63,10 @@ static void tty_serial_init(void) {
     outb(TTY_SERIAL_PORT + 0, 0x01);
     outb(TTY_SERIAL_PORT + 1, 0x00);
     outb(TTY_SERIAL_PORT + 3, 0x03);
-    outb(TTY_SERIAL_PORT + 2, 0xC7);
+    /* FCR = 0xC5: enable FIFO (bit0), clear TX only (bit2), 14-byte trigger (bits6-7).
+     * Bit1 (clear RX) is NOT set so bytes that arrived during GRUB's countdown
+     * are preserved in the FIFO for early userspace (matey) to read. */
+    outb(TTY_SERIAL_PORT + 2, 0xC5);
     outb(TTY_SERIAL_PORT + 4, 0x0B);
 }
 
@@ -272,18 +275,31 @@ int tty_ioctl(uint32_t request, void *arg) {
         case 0x5404:
             if (arg) memcpy(&tty_console.termios, arg, sizeof(tty_console.termios));
             return 0;
-        case 0x540F:
+        case 0x540F: {  /* TIOCGPGRP */
+            static uint32_t tiocgpgrp_count = 0;
             if (!arg) return -1;
             *(uint32_t*)arg = tty_console.fg_pgid;
+            if (tiocgpgrp_count++ < 5)
+                kprintf("[TTY] TIOCGPGRP: returning fg_pgid=%u\n", tty_console.fg_pgid);
             return 0;
-        case 0x5410:
+        }
+        case 0x5410: {  /* TIOCSPGRP */
             if (!arg) return -1;
+            kprintf("[TTY] TIOCSPGRP: fg_pgid %u -> %u\n",
+                    tty_console.fg_pgid, *(uint32_t*)arg);
             tty_console.fg_pgid = *(uint32_t*)arg;
             return 0;
+        }
         case 0x540E:
             return 0;
-        case 0x5422:
+        case 0x5422: {  /* TIOCSCTTY */
+            process_t *p = process_current();
+            if (p) {
+                tty_console.fg_pgid = p->pgid;
+                kprintf("[TTY] TIOCSCTTY: fg_pgid set to %u\n", p->pgid);
+            }
             return 0;
+        }
         default:
             return -1;
     }

--- a/kernel/tty.c
+++ b/kernel/tty.c
@@ -9,6 +9,7 @@
 #include "signal.h"
 #include "tty.h"
 #include "../lib/string.h"
+#include "../lib/stdio.h"
 
 static int tty_ready = 0;
 #define TTY_SERIAL_PORT 0x3F8
@@ -193,6 +194,15 @@ void tty_flush(void) {
 }
 
 void tty_input_char(char c) {
+    static uint32_t tty_in_count = 0;
+    if (tty_in_count < 50) {
+        kprintf("[TTY-IN#%u] 0x%02x '%c'\n",
+                tty_in_count,
+                (unsigned char)c,
+                (c >= 0x20 && c < 0x7f) ? c : '.');
+        tty_in_count++;
+    }
+
     if (tty_console.termios.c_iflag & TTY_IFLAG_ICRNL) {
         if (c == '\r') c = '\n';
     }
@@ -310,6 +320,10 @@ int tty_input_pending(void) {
 
 void tty_inject_raw(const char *buf, int len) {
     if (!buf || len <= 0) return;
+    kprintf("[TTY-INJECT] %d bytes:", len);
+    for (int i = 0; i < len && i < 8; i++)
+        kprintf(" %02x", (unsigned char)buf[i]);
+    kprintf("\n");
     for (int i = 0; i < len; i++)
         tty_input_push(buf[i]);
 }

--- a/kernel/tty.h
+++ b/kernel/tty.h
@@ -30,7 +30,9 @@ int  tty_is_ready(void);
 void tty_putchar(char c);
 void tty_write(const char *buf, size_t len);
 char tty_getchar(void);
+int  tty_getchar_nb(char *out); /* non-blocking: 0=no data, 1=got char */
 int  tty_read(char *buf, size_t len);
+int  tty_read_nb(char *buf, size_t len); /* non-blocking: 0=no data */
 void tty_flush(void);
 void tty_input_char(char c);
 int  tty_device_path_kind(const char *path);

--- a/kernel/tty.h
+++ b/kernel/tty.h
@@ -49,3 +49,6 @@ int tty_input_pending(void);
 /* Inject raw bytes directly into the TTY input buffer, bypassing ICANON/ECHO.
  * Used by the VT100 emulator to inject terminal responses (e.g. ESC[6n CPR). */
 void tty_inject_raw(const char *buf, int len);
+
+/* TTY termios l-flag bits exposed for drivers */
+#define TTY_LFLAG_ICANON 0x00000002u

--- a/kernel/tty.h
+++ b/kernel/tty.h
@@ -43,3 +43,7 @@ void tty_get_winsize(tty_winsize_t *winsize);
 
 /* Returns non-zero when terminal input is available (keyboard or serial). */
 int tty_input_pending(void);
+
+/* Inject raw bytes directly into the TTY input buffer, bypassing ICANON/ECHO.
+ * Used by the VT100 emulator to inject terminal responses (e.g. ESC[6n CPR). */
+void tty_inject_raw(const char *buf, int len);


### PR DESCRIPTION
This pull request introduces ACPI power management support to BlueyOS, implements improved POSIX errno handling, enhances VT100 terminal emulation, and refines filesystem and syscall error handling. The most significant changes are the addition of minimal ACPI table parsing and poweroff/reboot support, improved error codes for filesystem operations, and enhancements to system call behaviors for better Linux compatibility.

**Power Management and ACPI Support:**
* Added new `kernel/acpi.c` and `kernel/acpi.h` implementing minimal ACPI table parsing, enabling proper hardware-based poweroff and reboot via ACPI, with fallback to legacy methods. ACPI initialization is now called early in `kernel_main()` before paging is enabled. (`kernel/acpi.c`, `kernel/acpi.h`, `Makefile`, `kernel/kernel.c`) [[1]](diffhunk://#diff-c7a02357a10e68d38f3ea987771e773bc5045f22136c8ae4659e4c942b48675eR1-R214) [[2]](diffhunk://#diff-255bb61bcc72457c8d60f78e4d76a2c1e2615f77ae796566e42d41b7c8399032R1-R103) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R205) [[4]](diffhunk://#diff-d2dd205bb5b7dd5f41027a89752c90c4c53f70e9ac4c34a4116983888fa0348aR63) [[5]](diffhunk://#diff-d2dd205bb5b7dd5f41027a89752c90c4c53f70e9ac4c34a4116983888fa0348aR212-R215)
* Integrated ACPI reset and poweroff routines into the syscall layer. (`kernel/syscall.c`)

**Filesystem and Error Handling Improvements:**
* Introduced new POSIX-style kernel errno values (e.g., `BLUEY_EEXIST`, `BLUEY_ENOTDIR`) for improved error reporting and Linux compatibility. (`include/bluey.h`)
* Updated `biscuitfs` (BlueyFS) to return correct POSIX errors (e.g., `-BLUEY_EEXIST` for `mkdir` if the path exists), and added extensive debug logging to `unlink` and directory entry removal. (`fs/blueyfs.c`) [[1]](diffhunk://#diff-b94283b09cc92e7c0f28841eae43ffe194b3c42779624f41f54485118d307a08L1186-R1190) [[2]](diffhunk://#diff-b94283b09cc92e7c0f28841eae43ffe194b3c42779624f41f54485118d307a08L1283-R1307) [[3]](diffhunk://#diff-b94283b09cc92e7c0f28841eae43ffe194b3c42779624f41f54485118d307a08R771-R774)
* Enhanced `sys_rmdir()` and `sys_open()` to check path types and return appropriate errors like `ENOTDIR` for non-directories and enforce `O_DIRECTORY` semantics. (`kernel/syscall.c`) [[1]](diffhunk://#diff-b1f733b79050549824f690635919710099a0b0789fc3302fe34219a10ceeda19R1089-R1093) [[2]](diffhunk://#diff-b1f733b79050549824f690635919710099a0b0789fc3302fe34219a10ceeda19R2689-R2699) [[3]](diffhunk://#diff-b1f733b79050549824f690635919710099a0b0789fc3302fe34219a10ceeda19L2699-R2720)

**Terminal and TTY Improvements:**
* Improved VT100 terminal emulation to correctly handle device status reports (DSR/CPR), injecting cursor position replies into the TTY input buffer so userspace programs do not hang. (`drivers/vt100.c`) [[1]](diffhunk://#diff-4b4236869a057137d9bd33299695be74bb6361b6c0ff50433ad7abd874f77aa9R14) [[2]](diffhunk://#diff-4b4236869a057137d9bd33299695be74bb6361b6c0ff50433ad7abd874f77aa9L243-R263)

**Kernel Sync and Filesystem Reliability:**
* Refactored kernel sync logic into a single `kernel_sync()` function, ensuring all kernel state and filesystems are flushed to disk during `sync` and `reboot`. (`kernel/syscall.c`)

These changes collectively improve hardware compatibility, POSIX compliance, and system reliability, while providing better diagnostics and error handling.