### PR TITLE
Fix waitpid handling of WUNTRACED and implement stopped-child reporting

### DIFF
--- a/docs/DEFECT_ANALYSIS.md
+++ b/docs/DEFECT_ANALYSIS.md
@@ -45,6 +45,28 @@ monitoring tools had no `/proc` files to read.
 
 ---
 
+### K-13 🟠 `waitpid(WUNTRACED)` stopped-child events could be lost or duplicated
+**Status:** FIXED (this PR)
+
+Stopped-child reporting had two edge-case defects:
+
+- Re-sending stop signals (`SIGSTOP`, `SIGTSTP`, `SIGTTIN`, `SIGTTOU`) to an
+  already stopped process overwrote `stop_signal` and could trigger duplicate
+  parent wake/report for the same stopped state.
+- `waitpid()` only consumed pending stop events when the child was currently
+  `PROC_STOPPED`. If the child stopped and then continued before the parent
+  called `waitpid(WUNTRACED)`, the event could remain unreportable.
+
+**Fix applied:**
+- `kernel/signal.c`: only transition to `PROC_STOPPED`, record `stop_signal`,
+  and notify the parent when the process transitions from non-stopped to
+  stopped.
+- `kernel/process.c`: treat `stop_signal` as the authoritative pending
+  one-shot stop report in `process_waitpid()`, independent of current process
+  state.
+
+---
+
 ### K-1 🔴 Heap initialised AFTER first module load
 **Status:** FIXED (this PR)
 

--- a/kernel/process.c
+++ b/kernel/process.c
@@ -858,11 +858,11 @@ int32_t process_waitpid(int32_t pid, int *status, int options) {
                 process_complete_wait(current, process, 1);
                 return reaped_pid;
             }
-            /* Return immediately for a stopped child when WUNTRACED is set.
-             * stop_signal acts as a one-shot flag: we clear it on delivery so
-             * a subsequent waitpid() for the same stop event is not returned. */
-            if ((options & WUNTRACED) && process->state == PROC_STOPPED &&
-                    process->stop_signal) {
+            /* Return immediately for a child with a pending stop report when
+             * WUNTRACED is set. stop_signal acts as a one-shot flag: we clear
+             * it on delivery so a subsequent waitpid() for the same stop event
+             * is not returned, even if the child has since been continued. */
+            if ((options & WUNTRACED) && process->stop_signal) {
                 if (status) *status = ((int)process->stop_signal << 8) | 0x7f;
                 process->stop_signal = 0;
                 return (int32_t)process->pid;

--- a/kernel/process.c
+++ b/kernel/process.c
@@ -276,6 +276,29 @@ static void process_complete_wait(process_t *parent, process_t *child, int reap_
     }
 }
 
+/*
+ * When a child enters PROC_STOPPED, check if its parent is blocked in
+ * waitpid() with WUNTRACED and wake it if so.  Uses stop_signal as a
+ * one-shot flag: set by the stopper, cleared here after delivery so a
+ * second waitpid() call for the same stop event is not reported again.
+ */
+void process_notify_stopped_parent(process_t *child) {
+    process_t *parent;
+    if (!child || !child->stop_signal) return;
+    parent = child->parent_pid ? process_get_by_pid(child->parent_pid) : NULL;
+    if (!parent) return;
+    if (!(parent->wait_options & WUNTRACED)) return;
+    if (!process_wait_matches(parent, child)) return;
+
+    process_write_wait_status(parent, ((int)child->stop_signal << 8) | 0x7f);
+    child->stop_signal = 0; /* consumed — one-shot */
+    parent->saved_regs.eax = (int32_t)child->pid;
+    parent->state = PROC_READY;
+    parent->wait_pid = 0;
+    parent->wait_status_ptr = 0;
+    parent->wait_options = 0;
+}
+
 static void process_reap(process_t *process) {
     if (!process) return;
 
@@ -834,6 +857,15 @@ int32_t process_waitpid(int32_t pid, int *status, int options) {
                 if (status) *status = process->exit_code;
                 process_complete_wait(current, process, 1);
                 return reaped_pid;
+            }
+            /* Return immediately for a stopped child when WUNTRACED is set.
+             * stop_signal acts as a one-shot flag: we clear it on delivery so
+             * a subsequent waitpid() for the same stop event is not returned. */
+            if ((options & WUNTRACED) && process->state == PROC_STOPPED &&
+                    process->stop_signal) {
+                if (status) *status = ((int)process->stop_signal << 8) | 0x7f;
+                process->stop_signal = 0;
+                return (int32_t)process->pid;
             }
         }
 

--- a/kernel/process.c
+++ b/kernel/process.c
@@ -841,7 +841,7 @@ int32_t process_waitpid(int32_t pid, int *status, int options) {
     }
 
     if (!found_child) return -BLUEY_ECHILD;
-    if (options) return 0;
+    if (options & WNOHANG) return 0;
 
     current->state = PROC_WAITING;
     current->wait_pid = pid;

--- a/kernel/process.h
+++ b/kernel/process.h
@@ -76,6 +76,10 @@ typedef struct process {
     int32_t       wait_pid;
     uint32_t      wait_status_ptr;
     uint32_t      wait_options;
+    /* stop_signal: set to the stopping signal number when this process enters
+     * PROC_STOPPED; cleared to 0 after the parent's waitpid() has consumed
+     * the event (one-shot).  0 means no unreported stop. */
+    uint8_t       stop_signal;
     uint32_t      futex_wait_addr;
     uint32_t      futex_wait_deadline;
     int32_t       futex_wait_result;
@@ -145,3 +149,5 @@ void       process_enter_first_user(process_t *process);
 uint32_t   process_getppid(void);
 const char *process_get_cwd(void);
 void       process_set_cwd(const char *path);
+/* Notify a waiting parent that its child has stopped (called from signal.c). */
+void       process_notify_stopped_parent(process_t *child);

--- a/kernel/process.h
+++ b/kernel/process.h
@@ -88,6 +88,10 @@ typedef struct process {
     struct process *sched_next;
 } process_t;
 
+/* waitpid() option flags — match POSIX / musl values */
+#define WNOHANG    1  /* return immediately if no child has changed state */
+#define WUNTRACED  2  /* also report stopped children */
+
 #define PROC_FLAG_USER_MODE 0x00000001u
 #define PROC_FLAG_SIGNAL_ACTIVE 0x00000002u
 #define PROC_FLAG_VFORK_SHARED_VM 0x00000004u

--- a/kernel/signal.c
+++ b/kernel/signal.c
@@ -114,9 +114,11 @@ static int signal_apply_default_action(process_t *process, int sig) {
     if (signal_is_ignored_by_default(sig)) return 0;
 
     if (sig == SIGSTOP || sig == SIGTSTP || sig == SIGTTIN || sig == SIGTTOU) {
-        process->stop_signal = (uint8_t)sig;
-        process->state = PROC_STOPPED;
-        process_notify_stopped_parent(process);
+        if (process->state != PROC_STOPPED) {
+            process->stop_signal = (uint8_t)sig;
+            process->state = PROC_STOPPED;
+            process_notify_stopped_parent(process);
+        }
         return 1;
     }
 
@@ -173,9 +175,11 @@ int signal_send_pid(uint32_t pid, int sig) {
     if (sig == SIGKILL) {
         process_mark_exited(process, 128 + sig);
     } else if (sig == SIGSTOP || sig == SIGTSTP || sig == SIGTTIN || sig == SIGTTOU) {
-        process->stop_signal = (uint8_t)sig;
-        process->state = PROC_STOPPED;
-        process_notify_stopped_parent(process);
+        if (process->state != PROC_STOPPED) {
+            process->stop_signal = (uint8_t)sig;
+            process->state = PROC_STOPPED;
+            process_notify_stopped_parent(process);
+        }
     } else if (sig == SIGCONT) {
         process->pending_signals &= ~signal_bit(sig);
         if (process->state == PROC_STOPPED || process->state == PROC_WAITING) {

--- a/kernel/signal.c
+++ b/kernel/signal.c
@@ -114,7 +114,9 @@ static int signal_apply_default_action(process_t *process, int sig) {
     if (signal_is_ignored_by_default(sig)) return 0;
 
     if (sig == SIGSTOP || sig == SIGTSTP || sig == SIGTTIN || sig == SIGTTOU) {
+        process->stop_signal = (uint8_t)sig;
         process->state = PROC_STOPPED;
+        process_notify_stopped_parent(process);
         return 1;
     }
 
@@ -171,7 +173,9 @@ int signal_send_pid(uint32_t pid, int sig) {
     if (sig == SIGKILL) {
         process_mark_exited(process, 128 + sig);
     } else if (sig == SIGSTOP || sig == SIGTSTP || sig == SIGTTIN || sig == SIGTTOU) {
+        process->stop_signal = (uint8_t)sig;
         process->state = PROC_STOPPED;
+        process_notify_stopped_parent(process);
     } else if (sig == SIGCONT) {
         process->pending_signals &= ~signal_bit(sig);
         if (process->state == PROC_STOPPED || process->state == PROC_WAITING) {


### PR DESCRIPTION
This pull request adds support for POSIX-style reporting of stopped child processes in `waitpid()`, including the `WUNTRACED` and `WNOHANG` options, and ensures that stop events are only reported once per child. The changes also introduce a mechanism for notifying a parent process when its child is stopped by a signal.

**Support for stopped children and waitpid options:**

* Added the `stop_signal` field to `process_t` to track the signal that caused a process to stop, and ensure that stop events are only reported once per child (`kernel/process.h` [kernel/process.hR79-R82](diffhunk://#diff-5b98d67b7a03d62c4413d81fd9a88a6af0c6a607e701dd5dd4761509e3944e92R79-R82)).
* Implemented the `WUNTRACED` and `WNOHANG` option flags for `waitpid()` to control reporting of stopped children and non-blocking waits, matching POSIX/musl behavior (`kernel/process.h` [[1]](diffhunk://#diff-5b98d67b7a03d62c4413d81fd9a88a6af0c6a607e701dd5dd4761509e3944e92R95-R98) `kernel/process.c` [[2]](diffhunk://#diff-828440eba4efbbfaa1f7733c1927afc719e71edee0c5f460f0ccf04e38a3e51fR861-R876).
* Modified `process_waitpid()` to immediately return for a stopped child if `WUNTRACED` is set, and to honor `WNOHANG` for non-blocking waits (`kernel/process.c` [kernel/process.cR861-R876](diffhunk://#diff-828440eba4efbbfaa1f7733c1927afc719e71edee0c5f460f0ccf04e38a3e51fR861-R876)).

**Parent notification and signal handling:**

* Added the `process_notify_stopped_parent()` function to wake a parent blocked in `waitpid()` with `WUNTRACED` when its child enters the stopped state, ensuring the stop event is only reported once (`kernel/process.c` [[1]](diffhunk://#diff-828440eba4efbbfaa1f7733c1927afc719e71edee0c5f460f0ccf04e38a3e51fR279-R301) `kernel/process.h` [[2]](diffhunk://#diff-5b98d67b7a03d62c4413d81fd9a88a6af0c6a607e701dd5dd4761509e3944e92R152-R153).
* Updated signal handling so that when a process is stopped by a signal (e.g., `SIGSTOP`), the `stop_signal` field is set, the process state is updated, and the parent is notified if waiting (`kernel/signal.c` [[1]](diffhunk://#diff-d27dff658f39a6871b764e4efe94bef225af513a35f0d9f4f3009ca6c94f3767R117-R119) [[2]](diffhunk://#diff-d27dff658f39a6871b764e4efe94bef225af513a35f0d9f4f3009ca6c94f3767R176-R178).